### PR TITLE
Initial groundwork for apic support

### DIFF
--- a/mythril_core/src/apic.rs
+++ b/mythril_core/src/apic.rs
@@ -1,0 +1,245 @@
+#![deny(missing_docs)]
+
+use crate::error::{Error, Result};
+use raw_cpuid::CpuId;
+use x86::msr;
+
+/// APIC base physical address mask.
+const IA32_APIC_BASE_MASK: u64 = 0xffff_f000;
+/// xAPIC global enable mask
+const IA32_APIC_BASE_EN: u64 = 1 << 11;
+/// x2APIC enable mask
+const IA32_APIC_BASE_EXD: u64 = 1 << 10;
+/// BSP mask
+const IA32_APIC_BASE_BSP: u64 = 1 << 8;
+
+#[derive(Debug)]
+#[repr(u8)]
+/// ICR destination shorthand values
+pub enum DstShorthand {
+    /// No shorthand used
+    NoShorthand = 0x00,
+    // TODO(dlrobertson): Is there any reason to include self? AFAIK
+    // SELF_IPI negates the need for it.
+    /// Broadcast including myself
+    AllIncludingSelf = 0x02,
+    /// Broadcast excluding myself
+    AllExcludingSelf = 0x03,
+}
+
+#[derive(Debug)]
+#[repr(u8)]
+/// INIT IPI Level
+pub enum Level {
+    /// INIT IPI Level De-Assert
+    DeAssert = 0x00,
+    /// INIT IPI Level Assert
+    Assert = 0x01,
+}
+
+#[derive(Debug)]
+#[repr(u8)]
+/// ICR trigger modes
+pub enum TriggerMode {
+    /// Edge sensitive
+    Edge = 0x00,
+    /// Level sensitive
+    Level = 0x01,
+}
+
+#[derive(Debug)]
+#[repr(u8)]
+/// ICR mode of the Destination field
+pub enum DstMode {
+    /// Physical ID
+    Physical = 0x00,
+    /// Logical ID
+    Logical = 0x01,
+}
+
+#[derive(Debug)]
+#[repr(u8)]
+/// ICR delivery mode
+pub enum DeliveryMode {
+    /// Send interrupt vector to target
+    Fixed = 0x00,
+    #[doc(hidden)]
+    _Reserved0 = 0x01,
+    /// Send SMI interrupt to target
+    SMI = 0x02,
+    #[doc(hidden)]
+    _Reserved1 = 0x03,
+    /// Send NMI interrupt to target
+    NMI = 0x04,
+    /// Send INIT interrupt to target
+    Init = 0x05,
+    /// Send Start Up to target
+    StartUp = 0x06,
+    #[doc(hidden)]
+    _Reserved2 = 0x07,
+}
+
+/// Structure defining the interface for a local x2APIC
+#[derive(Debug)]
+pub struct LocalApic {
+    /// The raw value of the `IA32_APIC_BASE_MSR`
+    base_reg: u64,
+}
+
+impl LocalApic {
+    /// Create a new local x2APIC
+    ///
+    /// # Panics
+    ///
+    ///  - The CPU does not support X2APIC
+    ///  - Unable to get the `cpuid`
+    pub fn init() -> Result<LocalApic> {
+        // Ensure the CPU supports x2apic
+        let cpuid = CpuId::new();
+        match cpuid.get_feature_info() {
+            Some(finfo) if !finfo.has_x2apic() => {
+                return Err(Error::NotSupported);
+            }
+            Some(_) => (),
+            None => {
+                return Err(Error::NotSupported);
+            }
+        };
+
+        // Fetch the raw APIC BASE MSR
+        let raw_base = unsafe { msr::rdmsr(msr::IA32_APIC_BASE) };
+
+        // If the EXD bit is set, the EN bit must be set as well and
+        // there is no need to flip it again.
+        if raw_base & IA32_APIC_BASE_EXD == 0 {
+            unsafe {
+                msr::wrmsr(
+                    msr::IA32_APIC_BASE,
+                    raw_base | IA32_APIC_BASE_EN | IA32_APIC_BASE_EXD,
+                );
+            }
+        }
+
+        // Fetch the new value of the APIC BASE MSR
+        let base_reg = unsafe { msr::rdmsr(msr::IA32_APIC_BASE) };
+
+        let apic = LocalApic { base_reg };
+
+        // Enable the APIC in the Spurious Interrupt Vector Register
+        unsafe {
+            msr::wrmsr(msr::IA32_X2APIC_SIVR, 1 << 8);
+        }
+
+        // Clear the Error Status Register and read from it.
+        //
+        // TODO(dlrobertson):
+        //
+        // Many implementations seem to "Pound the ESR really hard over
+        // the head with a big hammer" here, but there is nothing in the
+        // spec that indicates why this is necessary. See
+        // arch/x86/kernel/apic/apic.c for details.
+        //
+        // The spec states the following in § 2.3.5.4
+        //
+        // > A write (of any value) to the ESR must be done to update the
+        // > register before attempting to read it.
+        //
+        // It makes no mention of reading the ESR after clearing it, but
+        // a few implementations were found that read and discarded the
+        // initial value of the MSR. For now we'll just stick to what the
+        // spec says, but this should be investigated a bit further.
+        apic.clear_esr();
+        Ok(apic)
+    }
+
+    /// The APIC ID
+    pub fn id(&self) -> usize {
+        unsafe { msr::rdmsr(msr::IA32_X2APIC_APICID) as usize }
+    }
+
+    /// The Logical APIC ID
+    ///
+    /// From the x2apic spec § 2.4.4:
+    ///
+    /// > Logical x2APIC ID = [(x2APIC ID[31:4] << 16) | (1 << x2APIC ID[3:0])]
+    pub fn logical_id(&self) -> u32 {
+        let id = unsafe { msr::rdmsr(msr::IA32_X2APIC_APICID) as u32 };
+        ((id & 0xffff_fff0) << 16) | (1 << (id & 0xf))
+    }
+
+    /// Processor is Bootstrap Processor
+    pub fn bsp(&self) -> bool {
+        (self.base_reg & IA32_APIC_BASE_BSP) != 0
+    }
+
+    /// Clear the Error Status Register
+    pub fn clear_esr(&self) {
+        unsafe {
+            msr::wrmsr(msr::IA32_X2APIC_ESR, 0x00);
+        }
+    }
+
+    /// Read the Error Status Register
+    pub fn esr(&self) -> u64 {
+        unsafe { msr::rdmsr(msr::IA32_X2APIC_ESR) }
+    }
+
+    /// The APIC Base Physical Address
+    pub fn base(&self) -> u64 {
+        self.base_reg & IA32_APIC_BASE_MASK
+    }
+
+    /// The raw APIC Base register
+    pub fn raw_base(&self) -> u64 {
+        self.base_reg
+    }
+
+    /// The local APIC Version
+    pub fn version(&self) -> u32 {
+        unsafe { msr::rdmsr(msr::IA32_X2APIC_VERSION) as u32 }
+    }
+
+    /// Send a End Of Interrupt
+    pub fn eoi(&self) {
+        unsafe {
+            msr::wrmsr(msr::IA32_X2APIC_EOI, 0x00);
+        }
+    }
+
+    /// Read the Interrupt Command Register
+    pub fn icr(&self) -> u64 {
+        unsafe { msr::rdmsr(msr::IA32_X2APIC_ICR) }
+    }
+
+    /// Set the Interrupt Command Register
+    pub fn send_ipi(
+        &self,
+        dst: u32,
+        dst_short: DstShorthand,
+        trigger: TriggerMode,
+        level: Level,
+        dst_mode: DstMode,
+        delivery_mode: DeliveryMode,
+        vector: u8,
+    ) {
+        let mut icr: u64 = (dst as u64) << 32;
+        icr |= (dst_short as u64) << 18;
+        icr |= (trigger as u64) << 15;
+        icr |= (level as u64) << 14;
+        icr |= (dst_mode as u64) << 11;
+        icr |= (delivery_mode as u64) << 8;
+        icr |= vector as u64;
+        // TODO(dlrobertson): Should we check for illegal vectors?
+        unsafe {
+            msr::wrmsr(msr::IA32_X2APIC_ICR, icr);
+        }
+    }
+
+    /// Send a IPI to yourself
+    pub fn self_ipi(&self, vector: u8) {
+        // TODO(dlrobertson): Should we check for illegal vectors?
+        unsafe {
+            msr::wrmsr(msr::IA32_X2APIC_SELF_IPI, vector as u64);
+        }
+    }
+}

--- a/mythril_core/src/error.rs
+++ b/mythril_core/src/error.rs
@@ -76,6 +76,7 @@ pub enum Error {
     MissingFile(String),
     NullPtr(String),
     NotSupported,
+    NotFound,
     Uefi(String),
     InvalidValue(String),
     InvalidDevice(String),

--- a/mythril_core/src/lib.rs
+++ b/mythril_core/src/lib.rs
@@ -25,6 +25,8 @@ pub mod linux;
 pub mod logger;
 pub mod memory;
 mod registers;
+/// Support for the RSDP.
+pub mod rsdp;
 pub mod tsc;
 pub mod vcpu;
 pub mod vm;

--- a/mythril_core/src/lib.rs
+++ b/mythril_core/src/lib.rs
@@ -15,6 +15,8 @@ extern crate alloc;
 #[macro_use]
 extern crate log;
 
+/// Support for the local APIC.
+pub mod apic;
 pub mod device;
 pub mod emulate;
 pub mod error;

--- a/mythril_core/src/rsdp.rs
+++ b/mythril_core/src/rsdp.rs
@@ -1,0 +1,230 @@
+#![deny(missing_docs)]
+use crate::error::{Error, Result};
+use byteorder::{ByteOrder, NativeEndian};
+use core::fmt;
+use core::ops::Range;
+use core::slice;
+
+/// Extented BIOS Data Area Start Address
+const EXTENDED_BIOS_DATA_START: usize = 0x000040e;
+/// Extented BIOS Data Area End Address
+const EXTENDED_BIOS_DATA_SIZE: usize = 0x800;
+/// Main BIOS Data Area Start Address
+const MAIN_BIOS_DATA_START: usize = 0x000e0000;
+/// Main BIOS Data Area End Address
+const MAIN_BIOS_DATA_SIZE: usize = 0x20000;
+/// Well Known RSDP Signature
+const RSDP_SIGNATURE: &[u8; 8] = b"RSD PTR ";
+
+/// Offsets from [ACPI § 5.2.5.3]
+///
+/// [ACPI § 5.2.5.3]: https://uefi.org/sites/default/files/resources/ACPI_6_3_May16.pdf
+mod offsets {
+    use super::*;
+    /// Well known bytes, "RST PTR ".
+    pub const SIGNATURE: Range<usize> = 0..8;
+    /// Checksum of the fields defined by ACPI 1.0.
+    pub const CHECKSUM: usize = 8;
+    /// OEM-supplied ID string.
+    pub const OEMID: Range<usize> = 9..15;
+    /// Revision of the structure. Zero for ACPI 1.0 and two for ACPI 2.0.
+    pub const REVISION: usize = 15;
+    /// 32-bit physical address of the RSDT.
+    pub const RSDT_ADDR: Range<usize> = 16..20;
+    /// Length of the XSDT table in bytes (ACPI 2.0 only).
+    pub const LENGTH: Range<usize> = 20..24;
+    /// 64-bit physical address of the XSDT (ACPI 2.0 only).
+    pub const XSDT_ADDR: Range<usize> = 24..32;
+    /// Checksum of entire structure (ACPI 2.0 only).
+    pub const EXT_CHECKSUM: usize = 32;
+    /// Size of the RSDP, including the reservied field.
+    pub const RESERVED: Range<usize> = 33..36;
+}
+
+/// Structure size of the RSDP for revision one.
+const RSDP_V1_SIZE: usize = offsets::RSDT_ADDR.end;
+/// Structure size of the RSDP for revision two.
+const RSDP_V2_SIZE: usize = offsets::RESERVED.end;
+
+/// The Root System Descriptor Pointer (RSDP)
+pub enum RSDP {
+    /// RSDP structure variant for version 1 (`revision == 0`).
+    V1 {
+        /// OEM Supplied string.
+        oemid: [u8; 6],
+        /// 32-bit physical address of the RSDT.
+        rsdt_addr: u32,
+    },
+    /// RSDP structure variant for version 2 (`revision == 2`).
+    V2 {
+        /// OEM Supplied string.
+        oemid: [u8; 6],
+        /// 32-bit physical address of the RSDT.
+        rsdt_addr: u32,
+        /// Length of the XSDT table in bytes.
+        length: u32,
+        /// 64-bit physical address of the XSDT.
+        xsdt_addr: u64,
+    },
+}
+
+impl fmt::Debug for RSDP {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            &RSDP::V1 { rsdt_addr, .. } => {
+                write!(f, "RSDP: revision=1.0 rsdt=0x{:x}", rsdt_addr)
+            }
+            &RSDP::V2 {
+                rsdt_addr,
+                xsdt_addr,
+                ..
+            } => write!(
+                f,
+                "RSDP: revision=2.0 rsdt=0x{:x} xsdt_addr=0x{:x}",
+                rsdt_addr, xsdt_addr
+            ),
+        }
+    }
+}
+
+impl RSDP {
+    /// Find the RSDP in the Extended BIOS Data Area or the
+    /// Main BIOS area.
+    ///
+    /// This is described in [ACPI § 5.2.5.1]
+    ///
+    /// [ACPI § 5.2.5.1]: https://uefi.org/sites/default/files/resources/ACPI_6_3_May16.pdf
+    pub fn find() -> Result<RSDP> {
+        let bytes = unsafe {
+            // Try to find the RSDP in the Extended BIOS Data Area (EBDA).
+            let range = slice::from_raw_parts(
+                EXTENDED_BIOS_DATA_START as *const u8,
+                EXTENDED_BIOS_DATA_SIZE,
+            );
+            Self::search_range(range).or_else(|_| {
+                let range = slice::from_raw_parts(
+                    MAIN_BIOS_DATA_START as *const u8,
+                    MAIN_BIOS_DATA_SIZE,
+                );
+                // If we didn't find the RSDP in the EBDA, try to find it in
+                // the Main BIOS Data.
+                Self::search_range(range)
+            })?
+        };
+        info!("RSDP: {:p}", bytes.as_ptr());
+
+        // Extract the OEMID, revision, and RSDT address from the address
+        // found regardless of the ACPI version.
+        let mut oemid = [0u8; offsets::OEMID.end - offsets::OEMID.start];
+        oemid.copy_from_slice(&bytes[offsets::OEMID]);
+
+        let rsdt_addr = NativeEndian::read_u32(&bytes[offsets::RSDT_ADDR]);
+
+        let rsdp = match bytes[offsets::REVISION] {
+            // If this is ACPI 1.0, there is no XSDT.
+            0 => RSDP::V1 { oemid, rsdt_addr },
+            // This is ACPI 2.0. Extract the addrss and length of the XSDT.
+            2 => RSDP::V2 {
+                oemid,
+                rsdt_addr,
+                length: NativeEndian::read_u32(&bytes[offsets::LENGTH]),
+                xsdt_addr: NativeEndian::read_u64(&bytes[offsets::XSDT_ADDR]),
+            },
+            _ => {
+                return Err(Error::InvalidValue(format!(
+                    "Invalid RSDP revision: {}",
+                    bytes[offsets::REVISION]
+                )))
+                .into();
+            }
+        };
+
+        // Now that we know this is a version we support, validate the checksum.
+        Self::verify_rsdp_checksum(bytes)?;
+        Ok(rsdp)
+    }
+
+    /// Search a given address range for the RSDP.
+    fn search_range(range: &[u8]) -> Result<&[u8]> {
+        let end = range.len() - RSDP_V1_SIZE;
+
+        // The RSDP is a two byte real mode segment pointer
+        //
+        // TODO(dlrobertson): are we sure it is two byte
+        // aligned?
+        for i in (0..end).step_by(2) {
+            let rsdp_v1_end = i + RSDP_V1_SIZE;
+            let rsdp_v2_end = i + RSDP_V2_SIZE;
+
+            // Initially set the candidate slice size to that of the
+            // smaller revision one structure.
+            let candidate = &range[i..rsdp_v1_end];
+
+            // If the RSDP structure is a revision 2 structure, add the
+            // extended info to the slice.
+            if &candidate[offsets::SIGNATURE] == RSDP_SIGNATURE {
+                return match candidate[offsets::REVISION] {
+                    0 => Ok(candidate),
+                    2 if rsdp_v2_end < range.len() => {
+                        Ok(&range[i..rsdp_v2_end])
+                    }
+                    _ => Err(Error::InvalidValue(format!(
+                        "Invalid RSDP revision: {} at {:p}",
+                        candidate[offsets::REVISION],
+                        candidate.as_ptr()
+                    ))),
+                };
+            }
+        }
+
+        Err(Error::NotFound)
+    }
+
+    /// Checksum validation for the RSDP.
+    fn verify_rsdp_checksum(bytes: &[u8]) -> Result<()> {
+        // Verify the RSDT checksum regardless of the ACPI version.
+        Self::verify_checksum(
+            bytes,
+            offsets::RSDT_ADDR.end,
+            offsets::CHECKSUM,
+        )?;
+
+        // We need to also validate the checksum of the extended data
+        // for ACPI 2.0.
+        match bytes[offsets::REVISION] {
+            0 => Ok(()),
+            2 => Self::verify_checksum(
+                bytes,
+                offsets::RESERVED.end,
+                offsets::EXT_CHECKSUM,
+            ),
+            _ => Err(Error::InvalidValue(format!(
+                "Invalid RSDP revision: {}",
+                bytes[offsets::REVISION]
+            ))),
+        }
+    }
+
+    fn verify_checksum(
+        bytes: &[u8],
+        length: usize,
+        cksum_idx: usize,
+    ) -> Result<()> {
+        // Sum up the bytes in the buffer.
+        let result = &bytes[..length]
+            .iter()
+            .fold(0usize, |acc, val| acc + *val as usize);
+
+        // The result of the sum should be zero. See the ACPI spec § 5.2.5.3
+        // in Table 5-27.
+        if (result & 0xff) == 0x00 {
+            Ok(())
+        } else {
+            Err(Error::InvalidValue(format!(
+                "Checksum mismatch cksum={:x} {:x} != 0x00",
+                bytes[cksum_idx],
+                result & 0xff,
+            )))
+        }
+    }
+}

--- a/mythril_core/src/vcpu.rs
+++ b/mythril_core/src/vcpu.rs
@@ -3,6 +3,7 @@ use crate::emulate;
 use crate::error::{self, Error, Result};
 use crate::memory::Raw4kPage;
 use crate::registers::{GdtrBase, IdtrBase};
+use crate::rsdp::RSDP;
 use crate::vm::VirtualMachine;
 use crate::{vmcs, vmexit, vmx};
 use alloc::boxed::Box;
@@ -38,6 +39,12 @@ pub fn smp_entry_point(
         local_apic.raw_base(),
         local_apic.version()
     );
+
+    let rsdp = match RSDP::find() {
+        Ok(rsdp) => rsdp,
+        Err(e) => panic!("Failed to find the RSDP: {:?}", e),
+    };
+    info!("{:?}", rsdp);
 
     let vm = vm_map
         .get(&local_apic.id())

--- a/mythril_core/src/vcpu.rs
+++ b/mythril_core/src/vcpu.rs
@@ -1,3 +1,4 @@
+use crate::apic::LocalApic;
 use crate::emulate;
 use crate::error::{self, Error, Result};
 use crate::memory::Raw4kPage;
@@ -10,7 +11,6 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::mem;
 use core::pin::Pin;
-use raw_cpuid::CpuId;
 use spin::RwLock;
 use x86::controlregs::{cr0, cr3, cr4};
 use x86::msr;
@@ -27,12 +27,21 @@ extern "C" {
 pub fn smp_entry_point(
     vm_map: &'static BTreeMap<usize, Arc<RwLock<VirtualMachine>>>,
 ) -> ! {
-    let cpuid = CpuId::new();
-    let apicid = match cpuid.get_feature_info() {
-        Some(finfo) => finfo.initial_local_apic_id() as usize,
-        _ => panic!("Unable to get cpuid"),
+    let local_apic = match LocalApic::init() {
+        Ok(local_apic) => local_apic,
+        Err(e) => panic!("{:?}", e),
     };
-    let vm = vm_map.get(&apicid).expect("Failed to locate VM for VCPU");
+
+    info!(
+        "X2APIC:\tid={}\tbase=0x{:x}\tversion=0x{:x}",
+        local_apic.id(),
+        local_apic.raw_base(),
+        local_apic.version()
+    );
+
+    let vm = vm_map
+        .get(&local_apic.id())
+        .expect("Failed to locate VM for VCPU");
     let vcpu = VCpu::new(vm.clone()).expect("Failed to create vcpu");
     vcpu.launch().expect("Failed to launch vm")
 }


### PR DESCRIPTION
Add `LocalApic` with basic x2apic support. Added the initial structure and methods for the `LocalApic`.

Related to: #26 