### PR TITLE
core: add support for the RSDT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,16 @@ MULTIBOOT2_TARGET?=multiboot2_target
 BUILD_TYPE?=release
 
 multiboot2_binary = target/$(MULTIBOOT2_TARGET)/$(BUILD_TYPE)/mythril_multiboot2
-multiboot2_debug_binary = target/$(MULTIBOOT2_TARGET)/debug/mythril_multiboot2
 mythril_src = $(shell find . -type f -name '*.rs' -or -name '*.S' -or -name '*.ld')
 seabios = seabios/out/bios.bin
 
 ifneq (,$(filter qemu%, $(firstword $(MAKECMDGOALS))))
     QEMU_EXTRA := $(subst :,\:, $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS)))
     $(eval $(QEMU_EXTRA):;@:)
+endif
+
+ifeq ($(BUILD_TYPE), release)
+    CARGO_FLAGS := --release
 endif
 
 .PHONY: all
@@ -19,7 +22,8 @@ all: multiboot2 $(seabios)
 multiboot2: $(multiboot2_binary)
 
 .PHONY: multiboot2-debug
-multiboot2-debug: $(multiboot2_debug_binary)
+multiboot2-debug: BUILD_TYPE=debug
+multiboot2-debug: $(multiboot2_binary)
 
 $(seabios):
 	cp scripts/seabios.config seabios/.config
@@ -35,12 +39,7 @@ qemu-debug: multiboot2-debug $(seabios)
 	    -gdb tcp::1234 -S $(QEMU_EXTRA)
 
 $(multiboot2_binary): $(mythril_src)
-	$(CARGO) xbuild --$(BUILD_TYPE) \
-	    --target mythril_multiboot2/$(MULTIBOOT2_TARGET).json \
-	    --manifest-path mythril_multiboot2/Cargo.toml
-
-$(multiboot2_debug_binary): $(mythril_src)
-	$(CARGO) xbuild \
+	$(CARGO) xbuild $(CARGO_FLAGS) \
 	    --target mythril_multiboot2/$(MULTIBOOT2_TARGET).json \
 	    --manifest-path mythril_multiboot2/Cargo.toml
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 CARGO?=cargo
 MULTIBOOT2_TARGET?=multiboot2_target
+BUILD_TYPE?=release
 
-multiboot2_binary = target/$(MULTIBOOT2_TARGET)/release/mythril_multiboot2
+multiboot2_binary = target/$(MULTIBOOT2_TARGET)/$(BUILD_TYPE)/mythril_multiboot2
 multiboot2_debug_binary = target/$(MULTIBOOT2_TARGET)/debug/mythril_multiboot2
 mythril_src = $(shell find . -type f -name '*.rs' -or -name '*.S' -or -name '*.ld')
 seabios = seabios/out/bios.bin
@@ -34,7 +35,7 @@ qemu-debug: multiboot2-debug $(seabios)
 	    -gdb tcp::1234 -S $(QEMU_EXTRA)
 
 $(multiboot2_binary): $(mythril_src)
-	$(CARGO) xbuild --release \
+	$(CARGO) xbuild --$(BUILD_TYPE) \
 	    --target mythril_multiboot2/$(MULTIBOOT2_TARGET).json \
 	    --manifest-path mythril_multiboot2/Cargo.toml
 

--- a/mythril_core/src/acpi/madt.rs
+++ b/mythril_core/src/acpi/madt.rs
@@ -1,0 +1,345 @@
+use super::rsdt::SDT;
+use crate::error::{Error, Result};
+use bitflags::bitflags;
+use byteorder::{ByteOrder, NativeEndian};
+use core::fmt;
+use core::ops::Range;
+use derive_try_from_primitive::TryFromPrimitive;
+
+/// See Table 5-43 in the ACPI spcification.
+///
+/// Note that these offsets are relative to the end of the
+/// SDT (the end of the Creator Revision at offset 36).
+mod offsets {
+    use super::*;
+    /// 32-bit physical address at which each processor can access its
+    /// local APIC.
+    pub const LOCAL_INT_CTRL_ADDR: Range<usize> = 0..4;
+    /// Multiple APIC Flags.
+    pub const FLAGS: Range<usize> = 4..8;
+    /// Interrupt Controller Structures
+    pub const INT_CTRL_STRUCTS: usize = 8;
+}
+
+/// Interrupt Controller Structure Type Values
+///
+/// See Table 5-45 in the APIC specification.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, TryFromPrimitive)]
+pub enum IcsType {
+    /// Processor Local APIC Structure Tag.
+    ProcessorLocalApic = 0x00,
+    /// I/O APIC Structure Tag.
+    IoApic = 0x01,
+    /// Interrupt Source Override Structure Tag.
+    InterruptSourceOverride = 0x02,
+    /// Non-Maskable Interrupt Source Structure Tag.
+    NmiSource = 0x03,
+    /// Local APIC NMI Structure Tag.
+    LocalApicNmi = 0x04,
+    /// Local APIC Address Override Structure Tag.
+    LocalApicAddressOverride = 0x05,
+    /// Platform Interrupt Source Structure Tag.
+    PlatformInterruptSource = 0x08,
+    /// Processor Local x2APIC Structure Tag.
+    ProcessorLocalX2Apic = 0x09,
+    /// Local x2APIC NMI Structure Tag.
+    LocalX2ApicNmi = 0x0a,
+}
+
+impl IcsType {
+    /// Expected length of buffer for ICS type.
+    ///
+    /// See the Structure definition tables found in
+    /// `ACPI § 5.2.12` for details.
+    pub fn expected_len(&self) -> usize {
+        match *self {
+            IcsType::ProcessorLocalApic => 8,
+            IcsType::IoApic => 12,
+            IcsType::InterruptSourceOverride => 10,
+            IcsType::NmiSource => 8,
+            IcsType::LocalApicNmi => 6,
+            IcsType::LocalApicAddressOverride => 12,
+            IcsType::PlatformInterruptSource => 16,
+            IcsType::ProcessorLocalX2Apic => 16,
+            IcsType::LocalX2ApicNmi => 12,
+        }
+    }
+
+    /// Check the length of bytes available for the given
+    /// ICS type.
+    pub fn check_len(&self, length: usize) -> Result<()> {
+        // The length includes the type and length bytes.
+        if length == self.expected_len() - 2 {
+            Ok(())
+        } else {
+            Err(Error::InvalidValue(format!(
+                "Invalid length={} for type=0x{:x}",
+                *self as u8, length
+            )))
+        }
+    }
+}
+
+bitflags! {
+    /// Local APIC Flags.
+    ///
+    /// See ACPI Table 5-47.
+    struct ApicFlags: u32 {
+        /// The processor is ready for use.
+        const ENABLED = 1;
+        /// If `ENABLED` bit is 0, the processor supports enabling this
+        /// processor during OS runtime. If `ENABLED` is 1, this bit is
+        /// reserved.
+        const ONLINE_CAPABLE = 1 << 1;
+    }
+}
+
+bitflags! {
+    /// MPS INI Flags.
+    ///
+    /// See ACPI Table 5-50
+    struct MpsIniFlags: u16 {
+        /// Active High Polarity.
+        const ACTIVE_HIGH = 0x0001;
+        /// Active Low Polarity.
+        const ACTIVE_LOW = 0x0003;
+        /// Edge-Triggered Trigger Mode.
+        const EDGE_TRIGGERED = 0x0004;
+        /// Level-Triggered Trigger Mode.
+        const LEVEL_TRIGGERED = 0x0000c;
+    }
+}
+
+/// Interrupt Controller Structures.
+pub enum Ics {
+    /// Processor Local APIC Structure.
+    ///
+    /// See `ACPI § 5.2.12.2`.
+    LocalApic {
+        /// Processor Object ID.
+        apic_uid: u8,
+        /// The processors local APIC ID.
+        apic_id: u8,
+        /// Local APIC Flags.
+        flags: u32,
+    },
+    /// I/O APIC Structure.
+    ///
+    /// See `ACPI § 5.2.12.3`.
+    IoApic {
+        /// I/O APIC ID.
+        ioapic_id: u8,
+        /// 32-bit physical address to access this I/O APIC.
+        ioapic_addr: *const u8,
+        /// Global System Interrupt number where this I/O APIC's interrupt
+        /// input starts.
+        gsi_base: u32,
+    },
+    /// Interrupt Source Override Structure.
+    ///
+    /// See `ACPI § 5.2.12.5`.
+    InterruptSourceOverride {
+        /// Bus-relative interrupt source.
+        source: u8,
+        /// Global System Interrupt that this bus-relative interrupt will
+        /// signal.
+        gsi: u32,
+        /// MPS INI Flags.
+        flags: u16,
+    },
+    /// Non-Maskable Interrupt Source Structure.
+    ///
+    /// See `ACPI § 5.2.12.6`.
+    NmiSource {
+        /// MPS INI Flags.
+        flags: u16,
+        /// Global System Interrupt that this NMI will signal.
+        gsi: u32,
+    },
+    /// Local APIC NMI Structure.
+    ///
+    /// See `ACPI § 5.2.12.7`.
+    LocalApicNmi {
+        /// Processor Object ID.
+        acpi_proc_uid: u8,
+        /// MPS INI Flags.
+        flags: u16,
+        /// Local APIC interrupt input LINTn to which NMI is connected.
+        local_apic_lint: u8,
+    },
+    /// Processor Local x2APIC Structure.
+    ///
+    /// See `ACPI § 5.2.12.12`.
+    LocalX2Apic {
+        /// Processor local x2APIC ID.
+        x2apic_id: u32,
+        /// Local APIC Flags.
+        flags: u32,
+        /// Processor Object ID.
+        apic_proc_uid: u32,
+    },
+}
+
+impl Ics {
+    /// Parse the given
+    fn parse<'a>(ty: IcsType, bytes: &'a [u8]) -> Result<Ics> {
+        ty.check_len(bytes.len())?;
+        match ty {
+            IcsType::ProcessorLocalApic => Ok(Ics::LocalApic {
+                apic_uid: bytes[0],
+                apic_id: bytes[1],
+                flags: NativeEndian::read_u32(&bytes[2..6]),
+            }),
+            IcsType::IoApic => {
+                let ioapic_addr = NativeEndian::read_u32(&bytes[2..6]);
+                Ok(Ics::IoApic {
+                    ioapic_id: bytes[0],
+                    ioapic_addr: ioapic_addr as *const u8,
+                    gsi_base: NativeEndian::read_u32(&bytes[6..10]),
+                })
+            }
+            IcsType::InterruptSourceOverride => {
+                Ok(Ics::InterruptSourceOverride {
+                    source: bytes[1],
+                    gsi: NativeEndian::read_u32(&bytes[2..6]),
+                    flags: NativeEndian::read_u16(&bytes[6..8]),
+                })
+            }
+            IcsType::NmiSource => Ok(Ics::NmiSource {
+                flags: NativeEndian::read_u16(&bytes[0..2]),
+                gsi: NativeEndian::read_u32(&bytes[2..6]),
+            }),
+            IcsType::LocalApicNmi => Ok(Ics::LocalApicNmi {
+                acpi_proc_uid: bytes[0],
+                flags: NativeEndian::read_u16(&bytes[1..3]),
+                local_apic_lint: bytes[3],
+            }),
+            IcsType::ProcessorLocalX2Apic => Ok(Ics::LocalX2Apic {
+                x2apic_id: NativeEndian::read_u32(&bytes[2..6]),
+                flags: NativeEndian::read_u32(&bytes[6..10]),
+                apic_proc_uid: NativeEndian::read_u32(&bytes[10..14]),
+            }),
+            _ => Err(Error::NotImplemented(format!(
+                "type=0x{:x} length={} not implemented",
+                ty as u8,
+                bytes.len()
+            ))),
+        }
+    }
+
+    /// The controll structure type for the value.
+    pub fn ics_type(&self) -> IcsType {
+        match self {
+            &Ics::LocalApic { .. } => IcsType::ProcessorLocalApic,
+            &Ics::IoApic { .. } => IcsType::IoApic,
+            &Ics::InterruptSourceOverride { .. } => {
+                IcsType::InterruptSourceOverride
+            }
+            &Ics::NmiSource { .. } => IcsType::NmiSource,
+            &Ics::LocalApicNmi { .. } => IcsType::LocalApicNmi,
+            &Ics::LocalX2Apic { .. } => IcsType::ProcessorLocalX2Apic,
+        }
+    }
+}
+
+/// Multiple APIC Descriptor Table (MADT).
+///
+/// See `ACPI § 5.2.12`.
+pub struct MADT<'a> {
+    /// System Descriptor Table Header for this structure.
+    sdt: &'a SDT<'a>,
+    /// 32-bit physical Local Interrupt Controller Address.
+    pub ica: *const u8,
+    /// Multiple APIC Flags. See `ACPI § 5.2.12` Table 5-44
+    /// for the flag values and their meaning.
+    pub flags: u32,
+    /// A TLV buffer of MADT specific structures.
+    ///
+    /// From `ACPI § 5.2.12`:
+    ///
+    /// > The first byte of each structure declares the type of that
+    /// > structure and the second byte declares the length of that
+    /// > structure.
+    ///
+    /// The Interrupt Controller Structure buffer is the data immediately
+    /// following the System Descriptor Table Header (`SDT`), and as a
+    /// result should have the same lifetime as the `SDT`.
+    ics: &'a [u8],
+}
+
+impl<'a> MADT<'a> {
+    /// Create a new MADT given a SDT.
+    pub fn new(sdt: &'a SDT<'a>) -> MADT<'a> {
+        let ica =
+            NativeEndian::read_u32(&sdt.table[offsets::LOCAL_INT_CTRL_ADDR]);
+        let flags = NativeEndian::read_u32(&sdt.table[offsets::FLAGS]);
+        let ics = &sdt.table[offsets::INT_CTRL_STRUCTS..];
+        MADT {
+            sdt,
+            flags,
+            ics,
+            ica: ica as *const u8,
+        }
+    }
+
+    /// Interrupt Controller Structures.
+    pub fn structures<'c, 'd: 'c>(&'d self) -> IcsIterator<'c> {
+        IcsIterator { bytes: self.ics }
+    }
+}
+
+/// Iterator for the Interrupt Controller Structures found in the MADT.
+pub struct IcsIterator<'a> {
+    bytes: &'a [u8],
+}
+
+impl<'a> IcsIterator<'a> {
+    /// Create a new Iterator for the Interrupt Controller Structures.
+    pub fn new(bytes: &'a [u8]) -> IcsIterator<'a> {
+        IcsIterator { bytes }
+    }
+}
+
+impl<'a> Iterator for IcsIterator<'a> {
+    type Item = Result<Ics>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if 2 > self.bytes.len() {
+            return None;
+        }
+
+        let ty = match IcsType::try_from(self.bytes[0]) {
+            Some(ty) => ty,
+            None => {
+                return Some(Err(Error::InvalidValue(format!(
+                    "Invalid ICS type: {}",
+                    self.bytes[0]
+                ))));
+            }
+        };
+        let len = self.bytes[1] as usize;
+
+        if len > self.bytes.len() {
+            return Some(Err(Error::InvalidValue(format!(
+                "Payload for type=0x{:x} and len={} to big for buffer len={}",
+                ty as u8,
+                len,
+                self.bytes.len()
+            ))));
+        }
+
+        let bytes = &self.bytes[2..len];
+
+        self.bytes = &self.bytes[len..];
+
+        Some(Ics::parse(ty, bytes))
+    }
+}
+
+impl<'a> fmt::Debug for MADT<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.sdt)?;
+        write!(f, " ICA={:p} flags=0x{:x}", self.ica, self.flags)
+    }
+}

--- a/mythril_core/src/acpi/mod.rs
+++ b/mythril_core/src/acpi/mod.rs
@@ -1,0 +1,34 @@
+#![deny(missing_docs)]
+
+//! # ACPI Support for the Mythril Hypervisor
+//!
+//! This module contains implementations for structures and functions
+//! described in the ACPI specification. For all ACPI specification
+//! references found in the code and documentation reffer to [ACPI 6.3].
+//!
+//! [ACPI 6.3]: https://uefi.org/sites/default/files/resources/ACPI_6_3_May16.pdf
+
+use crate::error::{Error, Result};
+
+/// Support for the Root System Descriptor Pointer (RSDP).
+pub mod rsdp;
+/// Support for the Root System Descriptor Table (RSDT).
+pub mod rsdt;
+
+/// Verify a one byte checksum for a given slice and length.
+pub(self) fn verify_checksum(bytes: &[u8], cksum_idx: usize) -> Result<()> {
+    // Sum up the bytes in the buffer.
+    let result = bytes.iter().fold(0usize, |acc, val| acc + *val as usize);
+
+    // The result of the sum should be zero. See the ACPI § 5.2.5.3
+    // in Table 5-27.
+    if (result & 0xff) == 0x00 {
+        Ok(())
+    } else {
+        Err(Error::InvalidValue(format!(
+            "Checksum mismatch checksum={:x} {:x} != 0x00",
+            bytes[cksum_idx],
+            result & 0xff,
+        )))
+    }
+}

--- a/mythril_core/src/acpi/mod.rs
+++ b/mythril_core/src/acpi/mod.rs
@@ -10,6 +10,8 @@
 
 use crate::error::{Error, Result};
 
+/// Support for the Multiple APIC Descriptor Table (MADT).
+pub mod madt;
 /// Support for the Root System Descriptor Pointer (RSDP).
 pub mod rsdp;
 /// Support for the Root System Descriptor Table (RSDT).

--- a/mythril_core/src/acpi/rsdt.rs
+++ b/mythril_core/src/acpi/rsdt.rs
@@ -1,0 +1,167 @@
+use super::verify_checksum;
+use crate::error::Result;
+use byteorder::{ByteOrder, NativeEndian};
+use core::fmt;
+use core::ops::Range;
+use core::slice;
+use core::str;
+
+/// Offsets from `ACPI § 5.2.6`
+mod offsets {
+    use super::*;
+    /// Well known bytes, "RST PTR ".
+    pub const SIGNATURE: Range<usize> = 0..4;
+    /// Length of the table.
+    pub const LENGTH: Range<usize> = 4..8;
+    /// The revision of the structure corresponding to the signature.
+    pub const REVISION: usize = 8;
+    /// The checksum of the entire table.
+    pub const CHECKSUM: usize = 9;
+    /// Revision of utility that created the structure
+    pub const CREATOR_REVISION: Range<usize> = 32..36;
+}
+
+/// A System Descriptor Table.
+///
+/// See Table 5-28 of `ACPI § 5.2.6` for a full description of the fields
+/// found in a System Descriptor Table (SDT) header.
+///
+/// The structure includes a pointer to the table which immediately follows
+/// the header. The contents of the table iare determined by the value of
+/// the signature.  See Table 5-29 of `ACPI § 5.2.6` for the full list of
+/// possible values for the `signature`.
+///
+/// Note that the SDT header should be the same even for the 32-bit RSDT
+/// and the 64-bit XSDT. It is up to the caller to handle the table based
+/// on the value of the `signature`.
+pub struct SDT<'a> {
+    /// Signature identifying the data contained in the table. See
+    /// Table 5-29 in the ACPI spec for the available signatures.
+    pub signature: [u8; 4],
+    /// Length of the table and header.
+    length: u32,
+    /// Version of the contained table.
+    pub revision: u8,
+    /// The raw pointer to the structure.
+    pub table: &'a [u8],
+}
+
+impl<'a> fmt::Debug for SDT<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}: rev={} length={} table={:p}",
+            str::from_utf8(&self.signature).unwrap(),
+            self.revision,
+            self.length,
+            self.table.as_ptr()
+        )
+    }
+}
+
+impl<'a> SDT<'a> {
+    /// Create a new 32-bit SDT.
+    /// Create a SDT header from an address.
+    ///
+    /// The function makes no assumption about the address size the table
+    /// may point to. The caller is expected to know if this SDT originated
+    /// from an XSDT (64-bit) or RSDT (32-bit).
+    pub unsafe fn new(sdt_addr: *const u8) -> Result<SDT<'a>> {
+        let mut signature = [0u8; 4];
+
+        let header = slice::from_raw_parts(
+            sdt_addr as *const u8,
+            offsets::CREATOR_REVISION.end,
+        );
+
+        signature.copy_from_slice(&header[offsets::SIGNATURE]);
+
+        let length = NativeEndian::read_u32(&header[offsets::LENGTH]);
+
+        let bytes = slice::from_raw_parts(header.as_ptr(), length as usize);
+
+        verify_checksum(bytes, offsets::CHECKSUM)?;
+
+        Ok(SDT {
+            signature,
+            length,
+            revision: header[offsets::REVISION],
+            table: &bytes[offsets::CREATOR_REVISION.end..],
+        })
+    }
+
+    /// The length of the data following the table.
+    pub fn len(&self) -> usize {
+        self.length as usize - offsets::CREATOR_REVISION.end
+    }
+
+    /// The data following the table as a slice of bytes.
+    pub fn data(&self) -> &[u8] {
+        self.table
+    }
+}
+
+/// The Root System Descriptor Table.
+pub struct RSDT<'a>(SDT<'a>);
+
+impl<'a> RSDT<'a> {
+    /// Create a new SDT.
+    pub fn new(rsdt_addr: u32) -> Result<RSDT<'a>> {
+        let sdt = unsafe { SDT::new(rsdt_addr as *const u8)? };
+        Ok(RSDT(sdt))
+    }
+
+    /// Return the number of entries in the table.
+    ///
+    /// Note: This is not the same as the length value of the header.
+    /// the the length value _includes_ the header.
+    pub fn num_entries(&self) -> usize {
+        self.0.len() / 4
+    }
+
+    /// Return an iterator for the SDT entries.
+    pub fn entries(&self) -> RSDTIterator<'a> {
+        RSDTIterator::new(self.0.table)
+    }
+}
+
+impl<'a> fmt::Debug for RSDT<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+/// Iterator for the SDT entries found in the RSDT.
+pub struct RSDTIterator<'a> {
+    table: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> RSDTIterator<'a> {
+    /// Create an iterator for the SDT entries in an RSDT.
+    pub fn new<'b: 'a>(table: &'b [u8]) -> RSDTIterator<'a> {
+        RSDTIterator { table, offset: 0 }
+    }
+}
+
+impl<'a> Iterator for RSDTIterator<'a> {
+    type Item = Result<SDT<'a>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.offset + 4;
+        if next <= self.table.len() {
+            let item = unsafe {
+                // TODO(dlrobertson): We currently only support the 32-bit RSDT.
+                // When we support the 64-bit XSDT, the table may point to an
+                // array of 64-bit pointers.
+                let ptr =
+                    NativeEndian::read_u32(&self.table[self.offset..next]);
+                self.offset = next;
+                SDT::new(ptr as *const u8)
+            };
+            Some(item)
+        } else {
+            None
+        }
+    }
+}

--- a/mythril_core/src/acpi/rsdt.rs
+++ b/mythril_core/src/acpi/rsdt.rs
@@ -1,5 +1,5 @@
 use super::verify_checksum;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use byteorder::{ByteOrder, NativeEndian};
 use core::fmt;
 use core::ops::Range;
@@ -122,6 +122,16 @@ impl<'a> RSDT<'a> {
     /// Return an iterator for the SDT entries.
     pub fn entries(&self) -> RSDTIterator<'a> {
         RSDTIterator::new(self.0.table)
+    }
+
+    /// Returns the first matching SDT for a given signature.
+    pub fn find_entry(&self, signature: &[u8]) -> Result<SDT<'a>> {
+        self.entries()
+            .find(|entry| match entry {
+                Ok(entry) if &entry.signature == signature => true,
+                _ => false,
+            })
+            .unwrap_or(Err(Error::NotFound))
     }
 }
 

--- a/mythril_core/src/apic.rs
+++ b/mythril_core/src/apic.rs
@@ -161,7 +161,7 @@ impl LocalApic {
     ///
     /// From the x2apic spec § 2.4.4:
     ///
-    /// > Logical x2APIC ID = [(x2APIC ID[31:4] << 16) | (1 << x2APIC ID[3:0])]
+    /// > Logical x2APIC ID = \[(x2APIC ID\[31:4\] << 16) | (1 << x2APIC ID\[3:0\])\]
     pub fn logical_id(&self) -> u32 {
         let id = unsafe { msr::rdmsr(msr::IA32_X2APIC_APICID) as u32 };
         ((id & 0xffff_fff0) << 16) | (1 << (id & 0xf))

--- a/mythril_core/src/lib.rs
+++ b/mythril_core/src/lib.rs
@@ -15,6 +15,8 @@ extern crate alloc;
 #[macro_use]
 extern crate log;
 
+/// Support for ACPI.
+pub mod acpi;
 /// Support for the local APIC.
 pub mod apic;
 pub mod device;
@@ -25,8 +27,6 @@ pub mod linux;
 pub mod logger;
 pub mod memory;
 mod registers;
-/// Support for the RSDP.
-pub mod rsdp;
 pub mod tsc;
 pub mod vcpu;
 pub mod vm;

--- a/mythril_core/src/rsdp.rs
+++ b/mythril_core/src/rsdp.rs
@@ -98,13 +98,13 @@ impl RSDP {
         let bytes = unsafe {
             // Try to find the RSDP in the Extended BIOS Data Area (EBDA).
             let range = slice::from_raw_parts(
-                EXTENDED_BIOS_DATA_START as *const u8,
-                EXTENDED_BIOS_DATA_SIZE,
+                MAIN_BIOS_DATA_START as *const u8,
+                MAIN_BIOS_DATA_SIZE,
             );
             Self::search_range(range).or_else(|_| {
                 let range = slice::from_raw_parts(
-                    MAIN_BIOS_DATA_START as *const u8,
-                    MAIN_BIOS_DATA_SIZE,
+                    EXTENDED_BIOS_DATA_START as *const u8,
+                    EXTENDED_BIOS_DATA_SIZE,
                 );
                 // If we didn't find the RSDP in the EBDA, try to find it in
                 // the Main BIOS Data.

--- a/mythril_multiboot2/src/main.rs
+++ b/mythril_multiboot2/src/main.rs
@@ -231,8 +231,21 @@ pub extern "C" fn kmain(multiboot_info_addr: usize) -> ! {
     }
 
     // Locate the RSDP and start ACPI parsing
-    let rsdp = rsdp::RSDP::find().expect("Failed to find the RSDP");
+    let rsdp = acpi::rsdp::RSDP::find().expect("Failed to find the RSDP");
     info!("{:?}", rsdp);
+
+    let rsdt = match rsdp.rsdt() {
+        Ok(rsdt) => rsdt,
+        Err(e) => panic!("Failed to create the RSDT: {:?}", e),
+    };
+    info!("{:?}", rsdt);
+
+    for entry in rsdt.entries() {
+        match entry {
+            Ok(sdt) => info!("{:?}", sdt),
+            Err(e) => info!("Malformed SDT: {:?}", e),
+        }
+    }
 
     let mut multiboot_services =
         services::Multiboot2Services::new(multiboot_info);


### PR DESCRIPTION
Add support for the Root System Descriptor Table in the `rsdt` module in
`mythril_core`.

Signed-off-by: Dan Robertson <daniel.robertson@starlab.io>