### PR TITLE
Add 'dev-init' make target

### DIFF
--- a/.mythril_githooks/pre-commit
+++ b/.mythril_githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+diff=$(cargo fmt -- --check)
+result=$?
+
+if [[ ${result} -ne 0 ]] ; then
+    cat <<\EOF
+There are some code style issues, run `cargo fmt` first.
+EOF
+    exit 1
+fi
+
+exit 0

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ multiboot2_binary = target/$(MULTIBOOT2_TARGET)/$(BUILD_TYPE)/mythril_multiboot2
 mythril_src = $(shell find . -type f -name '*.rs' -or -name '*.S' -or -name '*.ld' \
 	                   -name 'Cargo.toml')
 seabios = seabios/out/bios.bin
+git_hooks_src = $(wildcard .mythril_githooks/*)
+git_hooks = $(subst .mythril_githooks,.git/hooks,$(git_hooks_src))
 
 ifneq (,$(filter qemu%, $(firstword $(MAKECMDGOALS))))
     QEMU_EXTRA := $(subst :,\:, $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS)))
@@ -61,6 +63,15 @@ test: test_core
 clean:
 	$(CARGO) clean
 	make -C seabios clean
+
+.PHONY: dev-init
+dev-init: install-git-hooks
+
+.PHONY: install-git-hooks
+install-git-hooks: $(git_hooks)
+
+$(git_hooks): $(git_hooks_src)
+	ln -s $(shell realpath --relative-to=.git/hooks $<) $@
 
 .PHONY: help
 help:


### PR DESCRIPTION
Currently this just installs git hooks. Really I just want to ensure I don't keep winding up in these situations where I've done a bunch of work but it turns out there were formatting issues that are very annoying to rebase.

I feel like I've seen some idiomatic name for the make target to install git hooks and such, but I can't find an example now.