### PR TITLE
Add basic global time source

### DIFF
--- a/mythril_core/src/device/acpi.rs
+++ b/mythril_core/src/device/acpi.rs
@@ -3,7 +3,7 @@ use crate::device::{
 };
 use crate::error::Result;
 use crate::memory::GuestAddressSpaceViewMut;
-use crate::tsc;
+use crate::time;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
@@ -76,9 +76,9 @@ impl EmulatedDevice for AcpiRuntime {
         _space: GuestAddressSpaceViewMut,
     ) -> Result<()> {
         if port == self.pmtimer() {
+            let on_duration = time::now() - time::system_start_time();
             let pm_time =
-                tsc::read_tsc() * PMTIMER_HZ / (tsc::tsc_khz() * 1000);
-            info!("pm_time={}", pm_time);
+                (on_duration.as_nanos() * PMTIMER_HZ as u128) / 1_000_000_000;
             val.copy_from_u32(pm_time as u32);
         }
         Ok(())

--- a/mythril_core/src/lib.rs
+++ b/mythril_core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod linux;
 pub mod logger;
 pub mod memory;
 mod registers;
+pub mod time;
 pub mod tsc;
 pub mod vcpu;
 pub mod vm;

--- a/mythril_core/src/logger.rs
+++ b/mythril_core/src/logger.rs
@@ -1,3 +1,5 @@
+use crate::time;
+
 use core::fmt;
 use core::fmt::Write;
 use spin::Mutex;
@@ -36,9 +38,17 @@ impl log::Log for DirectLogger {
     }
 
     fn log(&self, record: &log::Record) {
+        let (stamp_sec, stamp_subsec) = if time::is_global_time_ready() {
+            let diff = time::now() - time::system_start_time();
+            (diff.as_secs(), diff.subsec_micros())
+        } else {
+            (0, 0)
+        };
         writeln!(
             DirectWriter {},
-            "MYTHRIL-{}: {}",
+            "[{:>4}.{:06}] MYTHRIL-{}: {}",
+            stamp_sec,
+            stamp_subsec,
             record.level(),
             *record.args()
         )

--- a/mythril_core/src/time.rs
+++ b/mythril_core/src/time.rs
@@ -1,0 +1,185 @@
+#![deny(missing_docs)]
+
+//! # Abstract time support
+//!
+//! This module contains types and traits related to time keeping in
+//! Mythril. Note that this does not include _date_ information, only
+//! abstract system clock, counter, and timer information.
+
+use crate::error::Result;
+use crate::tsc;
+
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+use core::time::Duration;
+
+static mut TIME_SRC: Option<&'static mut dyn TimeSource> = None;
+static mut START_TIME: Option<Instant> = None;
+
+/// Determine the best available global system `TimeSource` and calibrate it.
+pub unsafe fn init_global_time() -> Result<()> {
+    // Currently we only support using the TSC
+    TIME_SRC = Some(tsc::calibrate_tsc()?);
+    START_TIME = Some(now());
+    Ok(())
+}
+
+/// Get the current instant from the global system `TimeSource`.
+pub fn now() -> Instant {
+    unsafe {
+        TIME_SRC
+            .as_ref()
+            .expect("Global time source is not calibrated")
+            .now()
+    }
+}
+
+/// Get the instant the system was started (approximately) in terms
+/// of the global system `TimeSource`.
+pub fn system_start_time() -> Instant {
+    unsafe { START_TIME.expect("Global time source is not started") }
+}
+
+fn frequency() -> u64 {
+    unsafe {
+        TIME_SRC
+            .as_ref()
+            .expect("Global time source is not calibrated")
+            .frequency()
+    }
+}
+
+/// A point in time on the system in terms of the global system `TimeSource`
+///
+/// An `Instant` can be added/subtracted with a `Duration` to produce an
+/// `Instant` in the future or past. However, this requires that the global
+/// system time source be initialized, otherwise it will panic.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct Instant(pub u64);
+
+impl Add<Duration> for Instant {
+    type Output = Self;
+
+    fn add(self, other: Duration) -> Self {
+        let ticks = (frequency() as u128 * other.as_nanos()) / 1_000_000_000;
+        Instant(self.0 + ticks as u64)
+    }
+}
+
+impl AddAssign<Duration> for Instant {
+    fn add_assign(&mut self, other: Duration) {
+        *self = *self + other;
+    }
+}
+
+impl Sub<Duration> for Instant {
+    type Output = Self;
+
+    fn sub(self, other: Duration) -> Self {
+        let ticks = (frequency() as u128 * other.as_nanos()) / 1_000_000_000;
+        Instant(self.0 - ticks as u64)
+    }
+}
+
+impl SubAssign<Duration> for Instant {
+    fn sub_assign(&mut self, other: Duration) {
+        *self = *self - other;
+    }
+}
+
+impl Sub<Instant> for Instant {
+    type Output = Duration;
+
+    fn sub(self, other: Self) -> Duration {
+        let ticks = (self.0 as i128 - other.0 as i128).abs() as u64;
+        let ns = (ticks as u128 * 1_000_000_000) / frequency() as u128;
+        Duration::from_nanos(ns as u64)
+    }
+}
+
+/// A trait representing a counter on the system with a consistent frequency.
+pub trait TimeSource {
+    /// The current value of the counter.
+    fn now(&self) -> Instant;
+
+    /// The frequency this counter increments in ticks per second.
+    fn frequency(&self) -> u64;
+}
+
+enum TimerMode {
+    OneShot,
+    Periodic,
+}
+
+/// A one-shot or periodic timer.
+pub struct Timer {
+    duration: Duration,
+    mode: TimerMode,
+    started: Option<Instant>,
+}
+
+impl Timer {
+    /// Create a new one-shot timer.
+    pub fn one_shot(duration: Duration) -> Self {
+        Self {
+            duration: duration,
+            mode: TimerMode::OneShot,
+            started: None,
+        }
+    }
+
+    /// Create a new periodic timer.
+    pub fn periodic(period: Duration) -> Self {
+        Self {
+            duration: period,
+            mode: TimerMode::Periodic,
+            started: None,
+        }
+    }
+
+    /// Start the timer.
+    pub fn start(&mut self) {
+        self.started = Some(now());
+    }
+
+    /// Stop the timer.
+    pub fn stop(&mut self) {
+        self.started = None;
+    }
+
+    /// Returns whether the timer has been started.
+    pub fn started(&self) -> bool {
+        self.started.is_some()
+    }
+
+    /// Returns whether the timer is periodic
+    pub fn is_periodic(&self) -> bool {
+        match self.mode {
+            TimerMode::Periodic => true,
+            TimerMode::OneShot => false,
+        }
+    }
+
+    /// Returns whether the timer has elapsed
+    ///
+    /// Note that for a periodic timer, `reset` must still be called
+    /// before `elapsed` will return false after having elapsed once.
+    pub fn elapsed(&self) -> bool {
+        if !self.started() {
+            return false;
+        }
+
+        now() - self.started.unwrap() > self.duration
+    }
+
+    /// Reset this timer
+    ///
+    /// Set the effective start time for this timer to 'now' (as determined
+    /// bye the global system timer). This does nothing if the timer has not
+    /// been started.
+    pub fn reset(&mut self) {
+        if !self.started() {
+            return;
+        }
+        self.started = Some(now());
+    }
+}

--- a/mythril_core/src/time.rs
+++ b/mythril_core/src/time.rs
@@ -39,6 +39,11 @@ pub fn system_start_time() -> Instant {
     unsafe { START_TIME.expect("Global time source is not started") }
 }
 
+/// Returns whether the global system `TimeSource` has be initialized.
+pub fn is_global_time_ready() -> bool {
+    unsafe { TIME_SRC.is_some() }
+}
+
 fn frequency() -> u64 {
     unsafe {
         TIME_SRC

--- a/mythril_multiboot2/src/main.rs
+++ b/mythril_multiboot2/src/main.rs
@@ -220,8 +220,10 @@ pub extern "C" fn kmain(multiboot_info_addr: usize) -> ! {
         .map(|()| log::set_max_level(log::LevelFilter::Info))
         .expect("Failed to set logger");
 
-    // Calibrate the timers
-    unsafe { tsc::calibrate().expect("Failed to calibrate TSC") };
+    // Calibrate the global time source
+    unsafe {
+        time::init_global_time().expect("Failed to init global timesource")
+    }
 
     let multiboot_info = unsafe { multiboot2::load(multiboot_info_addr) };
 


### PR DESCRIPTION
This is the first step to having time tick in the guest context. Once we have a way to really inject interrupts into the guests, the timer will be extended to contain the IRQ the timer should trigger in the guest.