### PR TITLE
multiboot: Check RSDP checksum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "multiboot2"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -168,7 +168,7 @@ version = "0.1.0"
 dependencies = [
  "linked_list_allocator 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiboot2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multiboot2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mythril_core 0.1.0",
  "nasm-rs 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -307,7 +307,7 @@ dependencies = [
 "checksum linked_list_allocator 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5825aea823c659d0fdcdbe8c9b78baf56f3a10365d783db874f6d360df72626f"
 "checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum multiboot2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24835c1bfe38142c78aa2d00769b0d76239c4b583d92f817e6e0a4f3631f40d6"
+"checksum multiboot2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9a649a4ee63c693e6f1cdc048e80136f9863c75952c72508b8305b0b8889759"
 "checksum nasm-rs 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "fea4fa2ba8f650120445ddcf137d8a6370ff01d55f00e6b29e0ab01b7c846464"
 "checksum proc-macro-hack 0.5.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"

--- a/mythril_multiboot2/Cargo.toml
+++ b/mythril_multiboot2/Cargo.toml
@@ -8,7 +8,7 @@ license-file = "LICENSE"
 description = "A intel-focused hypervisor using VT-x/EPT"
 
 [dependencies]
-multiboot2 = "0.8.1"
+multiboot2 = "0.9.0"
 mythril_core = { version = "*", path = "../mythril_core" }
 log = { version = "0.4.8", default-features = false }
 linked_list_allocator = "0.8.1"


### PR DESCRIPTION
Updates multiboot2 from 0.8.2 to 0.9.0 and checks the RSDP checksum before using it.

Fixes #72 