### PR TITLE
acpi: build the RSDP and pass it to the guest

### DIFF
--- a/mythril/Cargo.lock
+++ b/mythril/Cargo.lock
@@ -124,6 +124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
 name = "multiboot"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +155,7 @@ dependencies = [
  "iced-x86",
  "linked_list_allocator",
  "log",
+ "managed",
  "multiboot",
  "multiboot2",
  "nasm-rs",

--- a/mythril/Cargo.toml
+++ b/mythril/Cargo.toml
@@ -25,6 +25,7 @@ raw-cpuid = "8.1.1"
 rlibc = "1.0.0"
 spin = "0.5"
 ux = { version = "0.1.3", default-features = false }
+managed = { version = "0.8.0", features = ["map", "alloc"], default-features = false }
 
 [dependencies.iced-x86]
 version = "1.8.0"

--- a/mythril/src/acpi/fadt.rs
+++ b/mythril/src/acpi/fadt.rs
@@ -548,7 +548,7 @@ mod test {
         assert_eq!(fadt.century, Some(0x32));
         assert_eq!(fadt.boot_architecture_flags, Some(0x10));
         assert_eq!(fadt.flags, Some(0x384a5));
-        let gas_bytes = vec![
+        let gas_bytes = [
             0x01, 0x08, 0x00, 0x00, 0xf9, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00,
         ];
@@ -559,49 +559,49 @@ mod test {
         assert_eq!(fadt.fadt_minor_version, Some(0x0));
         assert_eq!(fadt.x_firmware_control, Some(0x0));
         assert_eq!(fadt.x_dsdt, Some(0xddca61a0));
-        let gas_bytes = vec![
+        let gas_bytes = [
             0x01, 0x20, 0x00, 0x02, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00,
         ];
         let gas = GenericAddressStructure::new(&gas_bytes).unwrap();
         assert_eq!(fadt.x_pm1a_event_block, Some(gas));
-        let gas_bytes = vec![
+        let gas_bytes = [
             0x01, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00,
         ];
         let gas = GenericAddressStructure::new(&gas_bytes).unwrap();
         assert_eq!(fadt.x_pm1b_event_block, Some(gas));
-        let gas_bytes = vec![
+        let gas_bytes = [
             0x01, 0x10, 0x00, 0x02, 0x04, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00,
         ];
         let gas = GenericAddressStructure::new(&gas_bytes).unwrap();
         assert_eq!(fadt.x_pm1a_control_block, Some(gas));
-        let gas_bytes = vec![
+        let gas_bytes = [
             0x01, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00,
         ];
         let gas = GenericAddressStructure::new(&gas_bytes).unwrap();
         assert_eq!(fadt.x_pm1b_control_block, Some(gas));
-        let gas_bytes = vec![
+        let gas_bytes = [
             0x01, 0x08, 0x00, 0x01, 0x50, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00,
         ];
         let gas = GenericAddressStructure::new(&gas_bytes).unwrap();
         assert_eq!(fadt.x_pm2_control_block, Some(gas));
-        let gas_bytes = vec![
+        let gas_bytes = [
             0x01, 0x20, 0x00, 0x03, 0x08, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00,
         ];
         let gas = GenericAddressStructure::new(&gas_bytes).unwrap();
         assert_eq!(fadt.x_pm_timerblock, Some(gas));
-        let gas_bytes = vec![
+        let gas_bytes = [
             0x01, 0x80, 0x00, 0x01, 0x20, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00,
         ];
         let gas = GenericAddressStructure::new(&gas_bytes).unwrap();
         assert_eq!(fadt.x_gpe0_block, Some(gas));
-        let gas_bytes = vec![
+        let gas_bytes = [
             0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00,
         ];

--- a/mythril/src/acpi/mod.rs
+++ b/mythril/src/acpi/mod.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![deny(unused)]
 
 //! # ACPI Support for the Mythril Hypervisor
 //!
@@ -24,6 +25,8 @@ pub mod madt;
 pub mod rsdp;
 /// Support for the Root System Descriptor Table (RSDT).
 pub mod rsdt;
+/// Support for the seabios bootloader
+pub mod seabios;
 
 mod offsets {
     use core::ops::Range;
@@ -51,6 +54,13 @@ pub(self) fn verify_checksum(bytes: &[u8], cksum_idx: usize) -> Result<()> {
             result & 0xff,
         )))
     }
+}
+
+/// Calculate the one byte checksum for a given slice.
+pub(self) fn calc_checksum(bytes: &[u8]) -> u8 {
+    // Sum up the bytes in the buffer.
+    let sum = bytes.iter().fold(0u8, |acc, val| acc.wrapping_add(*val));
+    (0x100 - (sum as u16)) as u8
 }
 
 /// The size of a Generic Address Structure in bytes.

--- a/mythril/src/acpi/seabios.rs
+++ b/mythril/src/acpi/seabios.rs
@@ -1,0 +1,261 @@
+//! Structures and methods for using the seabios table-loader feature
+//!
+//! # Basics
+//!
+//! If seabios is compiled with the `CONFIG_FW_ROMFILE_LOAD` option,
+//! seabios has a feature that will allow the user to write the
+//! ACPI tables by loading a fw_cfg file to `etc/table-loader`.
+//! The table loader may contain a series of commands that allocate
+//! bytes and copy them to a bios data region, add pointers to a
+//! previously allocated region, update the checksum value, or write
+//! a pointer back to a fw_cfg file.
+//!
+//! # Commands
+//!
+//! ## Allocate
+//!
+//! Allocates the contents of a fw_cfg file in a bios data region.
+//! This command must occur first for any fw_cfg file that will be
+//! used by the add checksum or add pointer command.
+//!
+//! ## Add Pointer
+//!
+//! Adds a pointer of the given size at the given offset in a
+//! destination table with points to the given source table. In
+//! practice this is helpful for building the RSDT or XSDT with
+//! an add pointer command occuring for each SDT in the root table.
+//!
+//! ## Write Pointer
+//!
+//! Writes a pointer back to a destination host file.
+//!
+//! ## Checksum
+//!
+//! Updates the checksum of a given table at a given offset. The checksum
+//! is calculated for the range given and added to the current checksum
+//! in the table.
+//!
+//! # Examples
+//!
+//! ```
+//! # use mythril::acpi::seabios::{AllocZone, TableLoaderBuilder, TableLoaderCommand};
+//! // Create a backing buffer and the table loader builder
+//! let tl_buf = [0x00; 512];
+//! let mut tl_builder = TableLoaderBuilder::new(&mut tl_buf[..]).unwrap();
+//!
+//! // Allocate a previously loaded fw_cfg file
+//! tl_builder.add_command(TableLoaderCommand::Allocate {
+//!     file: "etc/mythril/myrsdp",
+//!     align: 0x10,
+//!     zone: AllocZone::Fseg,
+//! }).unwrap();
+//!
+//! // Allocate a previously created RSDT
+//! tl_builder.add_command(TableLoaderCommand::Allocate {
+//!     file: "etc/mythril/myrsdt",
+//!     align: 0x10,
+//!     zone: AllocZone::Fseg,
+//! }).unwrap();
+//!
+//! // Add a pointer to the created RSDT to the RSDP
+//! tl_builder.add_command(TableLoaderCommand::AddPointer {
+//!     src: "etc/mythril/myrsdt",
+//!     dst: "etc/mythril/myrsdp",
+//!     offset: 16,
+//!     size: 4,
+//! }).unwrap();
+//! ```
+//!
+//! # Protocol
+//!
+//! ## Command Structure
+//!
+//! All entries must be 128 bytes long and the first 4 bytes contain
+//! the command type. The command types currently supported are as
+//! follows:
+//!
+//!  - 1: Allocate
+//!  - 2: Add Pointer
+//!  - 3: Add Checksum
+//!  - 4: Write Pointer
+//!
+//! All numbers that are more than one byte are Little Endian.
+
+use crate::error::{Error, Result};
+use crate::virtdev::qemu_fw_cfg::QemuFwCfgBuilder;
+
+use arrayvec::{Array, ArrayVec};
+use byteorder::{ByteOrder, LittleEndian};
+use num_enum::TryFromPrimitive;
+
+/// The maximum size for a given romfile.
+const ROMFILE_FILENAME_SIZE: usize = 56;
+
+/// The allocation zone for the given romfile.
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, TryFromPrimitive)]
+pub enum AllocZone {
+    /// The high allocation zone
+    High = 0x01,
+    /// The fseg allocation zone
+    Fseg = 0x02,
+}
+
+/// A command entry for the table loader.
+pub enum TableLoaderCommand<'a> {
+    /// Allocate a table from `file`.
+    ///
+    /// Must appear exactly once for each file, and before
+    /// this file is referenced by any other command.
+    Allocate {
+        /// The file to allocate
+        file: &'a str,
+        /// The alignment the alloc is subject to
+        align: u32,
+        /// May be FSEG or HIGH.
+        zone: AllocZone,
+    },
+    /// Patch the given table with a pointer to another table
+    AddPointer {
+        /// The table to patch
+        dst: &'a str,
+        /// The file the pointer added will point to
+        src: &'a str,
+        /// The offset in `dst` the pointer should be added at
+        offset: u32,
+        /// The size of the pointer to be added
+        size: u8,
+    },
+    /// Update the checksum of the given table
+    AddChecksum {
+        /// The table the checksum needs to be updated in
+        file: &'a str,
+        /// The offset of the checksum
+        offset: u32,
+        /// The start offset the checksum calculation should star at
+        start: u32,
+        /// The length of the checksum buffer to calculate
+        length: u32,
+    },
+    /// Write back to a host file
+    WritePointer {
+        /// The table to patch
+        dst: &'a str,
+        /// The file the pointer added will point to
+        src: &'a str,
+        /// The offset in `dst` the pointer should be added at
+        dst_offset: u32,
+        /// The offset in `src` the pointer should point to
+        src_offset: u32,
+        /// THe size of the pointer
+        size: u8,
+    },
+}
+
+impl<'a> TableLoaderCommand<'a> {
+    fn encode<T: Array<Item = u8>>(
+        &self,
+        buffer: &mut ArrayVec<T>,
+    ) -> Result<()> {
+        let mut bytes = [0x00; 128];
+        match self {
+            Self::Allocate { file, align, zone } => {
+                if file.len() >= ROMFILE_FILENAME_SIZE {
+                    Err(Error::NotSupported)
+                } else {
+                    // Write out the CMD_ALLOC command
+                    LittleEndian::write_u32(&mut bytes[..4], 1);
+                    bytes[4..(4 + file.len())].copy_from_slice(file.as_bytes());
+                    LittleEndian::write_u32(&mut bytes[60..64], *align);
+                    bytes[64] = *zone as u8;
+                    Ok(())
+                }
+            }
+            Self::AddPointer {
+                dst,
+                src,
+                offset,
+                size,
+            } => {
+                if src.len() >= ROMFILE_FILENAME_SIZE
+                    || dst.len() >= ROMFILE_FILENAME_SIZE
+                {
+                    Err(Error::NotSupported)
+                } else {
+                    LittleEndian::write_u32(&mut bytes[..4], 2);
+                    bytes[4..(4 + dst.len())].copy_from_slice(dst.as_bytes());
+                    bytes[60..(60 + src.len())].copy_from_slice(src.as_bytes());
+                    LittleEndian::write_u32(&mut bytes[116..120], *offset);
+                    bytes[120] = *size;
+                    Ok(())
+                }
+            }
+            Self::AddChecksum {
+                file,
+                offset,
+                start,
+                length,
+            } => {
+                if file.len() >= ROMFILE_FILENAME_SIZE {
+                    Err(Error::NotSupported)
+                } else {
+                    LittleEndian::write_u32(&mut bytes[..4], 3);
+                    bytes[4..(4 + file.len())].copy_from_slice(file.as_bytes());
+                    LittleEndian::write_u32(&mut bytes[60..64], *offset);
+                    LittleEndian::write_u32(&mut bytes[64..68], *start);
+                    LittleEndian::write_u32(&mut bytes[68..72], *length);
+                    Ok(())
+                }
+            }
+            Self::WritePointer {
+                dst,
+                src,
+                dst_offset,
+                src_offset,
+                size,
+            } => {
+                if src.len() >= ROMFILE_FILENAME_SIZE
+                    || dst.len() >= ROMFILE_FILENAME_SIZE
+                {
+                    Err(Error::NotSupported)
+                } else {
+                    LittleEndian::write_u32(&mut bytes[..4], 4);
+                    bytes[4..(4 + dst.len())].copy_from_slice(dst.as_bytes());
+                    bytes[60..(60 + src.len())].copy_from_slice(src.as_bytes());
+                    LittleEndian::write_u32(&mut bytes[116..120], *dst_offset);
+                    LittleEndian::write_u32(&mut bytes[120..124], *src_offset);
+                    bytes[124] = *size;
+                    Ok(())
+                }
+            }
+        }?;
+        buffer.try_extend_from_slice(&bytes)?;
+        Ok(())
+    }
+}
+
+/// Builder structure for a seabios table loader
+pub struct TableLoaderBuilder<T: Array<Item = u8>>(ArrayVec<T>);
+
+impl<T: Array<Item = u8>> TableLoaderBuilder<T> {
+    const TABLE_LOADER_NAME: &'static str = "etc/table-loader";
+
+    /// Create a empty table loader
+    pub fn new() -> Result<Self> {
+        Ok(TableLoaderBuilder(ArrayVec::<T>::new()))
+    }
+
+    /// Add the given command entry to the table loader
+    pub fn add_command(&mut self, cmd: TableLoaderCommand) -> Result<()> {
+        cmd.encode(&mut self.0)
+    }
+
+    /// Load the table loader to a fw_cfg file
+    pub fn load(
+        &mut self,
+        fw_cfg_builder: &mut QemuFwCfgBuilder,
+    ) -> Result<()> {
+        fw_cfg_builder.add_file(Self::TABLE_LOADER_NAME, self.0.as_slice())?;
+        Ok(())
+    }
+}

--- a/mythril/src/error.rs
+++ b/mythril/src/error.rs
@@ -1,6 +1,8 @@
 use crate::vmcs;
 use alloc::string::String;
+use arrayvec::CapacityError;
 use core::convert::TryFrom;
+use core::num::TryFromIntError;
 use num_enum::{TryFromPrimitive, TryFromPrimitiveError};
 use x86::bits64::rflags;
 use x86::bits64::rflags::RFlags;
@@ -78,6 +80,8 @@ pub enum Error {
     NullPtr(String),
     NotSupported,
     NotFound,
+    Exists,
+    Exhausted,
     Uefi(String),
     InvalidValue(String),
     InvalidDevice(String),
@@ -88,6 +92,24 @@ pub enum Error {
 impl<T: TryFromPrimitive> From<TryFromPrimitiveError<T>> for Error {
     fn from(error: TryFromPrimitiveError<T>) -> Error {
         Error::InvalidValue(format!("{}", error))
+    }
+}
+
+impl From<TryFromIntError> for Error {
+    fn from(error: TryFromIntError) -> Error {
+        Error::InvalidValue(format!("{}", error))
+    }
+}
+
+impl From<core::str::Utf8Error> for Error {
+    fn from(error: core::str::Utf8Error) -> Error {
+        Error::InvalidValue(format!("{}", error))
+    }
+}
+
+impl<T> From<CapacityError<T>> for Error {
+    fn from(_error: CapacityError<T>) -> Error {
+        Error::Exhausted
     }
 }
 


### PR DESCRIPTION
Build the RSDP and pass it to the guest via the seabios table-loader feature.
We also now fill out the MADT with a implementation of the `SDTBuilder`
trait and the `MADTBuilder`

As seen below, we do indeed control the RSDP and the Interrupt Control
Address (in this case a bad address).

```
GUEST0: Copying ACPI RSDP from 0x40000008 to 0x000f4ca0
GUEST1: Copying ACPI RSDP from 0x40000008 to 0x000f4ca0
...
GUEST0: [    0.000000][    T0] ACPI: RSDP 0x00000000000F4CA0 000024 (v02       )
GUEST1: [    0.000000][    T0] ACPI: RSDP 0x00000000000F4CA0 000024 (v02       )
GUEST0: [    0.000000][    T0] ACPI: XSDT 0x0000000040001000 00002C (v01                 00000000      00000000)
GUEST1: [    0.000000][    T0] ACPI: XSDT 0x0000000040001000 00002C (v01                 00000000      00000000)
GUEST0: [    0.000000][    T0] ACPI: APIC 0x0000000040002000 000040 (v05                 00000000      00000000)
GUEST1: [    0.000000][    T0] ACPI: APIC 0x0000000040002000 000040 (v05                 00000000      00000000)
GUEST0: [    0.000000][    T0] ACPI: Local APIC address 0xdeadbeef
GUEST1: [    0.000000][    T0] ACPI: Local APIC address 0xdeadbeef
```

Fixes: #69 