### PR TITLE
Add support for legacy multiboot

### DIFF
--- a/mythril/Cargo.lock
+++ b/mythril/Cargo.lock
@@ -124,6 +124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiboot"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "745e351d4f128ea9e266fe2dd04a1bd7349c60441d45ec8677520bae08e25d43"
+
+[[package]]
 name = "multiboot2"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +149,7 @@ dependencies = [
  "iced-x86",
  "linked_list_allocator",
  "log",
+ "multiboot",
  "multiboot2",
  "nasm-rs",
  "num_enum",

--- a/mythril/Cargo.toml
+++ b/mythril/Cargo.toml
@@ -19,6 +19,7 @@ num_enum = { version = "0.5.0", default-features = false }
 x86 = "0.34.0"
 linked_list_allocator = "0.8.1"
 log = { version = "0.4.8", default-features = false }
+multiboot = "0.3.0"
 multiboot2 = "0.9.0"
 raw-cpuid = "8.1.1"
 rlibc = "1.0.0"

--- a/mythril/build.rs
+++ b/mythril/build.rs
@@ -12,6 +12,7 @@ fn main() {
     build
         .file("src/vm.S")
         .file("src/boot.S")
+        .file("src/multiboot_header.S")
         .file("src/multiboot2_header.S")
         .file("src/ap_startup.S")
         .include("asm_include/")

--- a/mythril/linker.ld
+++ b/mythril/linker.ld
@@ -3,18 +3,18 @@ ENTRY(_start)
 SECTIONS {
     . = 0x8000;
 
+    .boot :
+    {
+        /* ensure that the multiboot header is at the beginning */
+        KEEP(*(.multiboot_header))
+    }
+
     .ap_startup ALIGN(4K) : ALIGN(4K)
     {
        KEEP(*(.ap_startup .ap_startup.*))
     }
 
     . = 1M;
-
-    .boot ALIGN(4K) : ALIGN(4K)
-    {
-        /* ensure that the multiboot header is at the beginning */
-        KEEP(*(.multiboot_header))
-    }
 
     PER_CORE_START = .;
     .per_core :
@@ -47,4 +47,6 @@ SECTIONS {
         *(.bss .bss.*)
         *(COMMON)
     }
+
+    END_OF_BINARY = .;
 }

--- a/mythril/src/boot.S
+++ b/mythril/src/boot.S
@@ -9,7 +9,7 @@ PAGE_HIERARCHY:
    align PAGE_SIZE
    resb PAGE_HIERARCHY_SIZE
 
-extern kmain_multiboot2
+extern kmain_early
 
 ; The stack used before launching the guests. After that, the
 ; stack will be the one set up in the VMCS
@@ -66,6 +66,14 @@ global GDT64_DATA
 GDT64_DATA:
      dq GDT64.data
 
+global IS_MULTIBOOT_BOOT
+IS_MULTIBOOT_BOOT:
+     db 0
+
+global IS_MULTIBOOT2_BOOT
+IS_MULTIBOOT2_BOOT:
+     db 0
+
 [BITS 32]
 
 section .text.map_page_directory
@@ -93,6 +101,17 @@ _start:
     lea edi, [PAGE_HIERARCHY]
 
     push ebx
+
+
+    cmp eax, 0x36d76289         ; Multiboot2 indicator
+    je .multiboot2_boot_type
+    mov byte [IS_MULTIBOOT_BOOT], 1
+    jmp .post_boot_type
+
+.multiboot2_boot_type:
+    mov byte [IS_MULTIBOOT2_BOOT], 1
+
+.post_boot_type:
 
     ; Zero out the buffer.
     ; Since we are doing a rep stosd, count should be bytes/4.
@@ -215,4 +234,4 @@ trampoline:
     mov edx, 0
     mov fs, edx
 
-    jmp kmain_multiboot2
+    jmp kmain_early

--- a/mythril/src/lib.rs
+++ b/mythril/src/lib.rs
@@ -39,6 +39,7 @@ pub mod linux;
 pub mod lock;
 pub mod logger;
 pub mod memory;
+pub mod multiboot;
 pub mod multiboot2;
 pub mod percore;
 pub mod physdev;

--- a/mythril/src/multiboot.rs
+++ b/mythril/src/multiboot.rs
@@ -1,0 +1,116 @@
+use crate::boot_info::{self, BootInfo};
+use crate::global_alloc;
+use crate::memory::HostPhysAddr;
+use alloc::vec::Vec;
+
+extern "C" {
+    pub static MULTIBOOT_HEADER_START: u32;
+    pub static MULTIBOOT_HEADER_END: u32;
+
+    // The _value_ of the last byte of the mythril binary. The
+    // address of this symbol is the actual end.
+    pub static END_OF_BINARY: u8;
+}
+
+// NOTE: see multiboot2::header_location for more information
+pub fn header_location() -> (u32, u32) {
+    unsafe { (MULTIBOOT_HEADER_START, MULTIBOOT_HEADER_END) }
+}
+
+fn setup_global_alloc_region<'a, F>(
+    info: &'a multiboot::Multiboot<'a, F>,
+) -> (u64, u64)
+where
+    F: Fn(u64, usize) -> Option<&'a [u8]>,
+{
+    let regions = info
+        .memory_regions()
+        .expect("Missing multiboot memory regions");
+
+    let available = regions.filter_map(|region| match region.memory_type() {
+        multiboot::MemoryType::Available => Some((
+            region.base_address(),
+            region.base_address() + region.length(),
+        )),
+        _ => None,
+    });
+
+    debug!("Modules:");
+    let modules =
+        info.modules()
+            .expect("No multiboot modules found")
+            .map(|module| {
+                debug!("  0x{:x}-0x{:x}", module.start, module.end);
+                (module.start, module.end)
+            });
+
+    // Avoid allocating over the actual mythril binary (just use 0 as the start
+    // for now).
+    let mythril_bounds =
+        [(0 as u64, unsafe { &END_OF_BINARY as *const u8 as u64 })];
+    debug!(
+        "Mythril binary bounds: 0x{:x}-0x{:x}",
+        mythril_bounds[0].0, mythril_bounds[0].1
+    );
+
+    let excluded = modules.chain(mythril_bounds.iter().copied());
+
+    // TODO(alschwalm): For now, we just use the portion of the largest available
+    // region that is above the highest excluded region.
+    let max_excluded = excluded
+        .max_by(|left, right| left.1.cmp(&right.1))
+        .expect("No max excluded region");
+
+    let largest_region = available
+        .max_by(|left, right| (left.1 - left.0).cmp(&(right.1 - right.0)))
+        .expect("No largest region");
+
+    if largest_region.0 > max_excluded.1 {
+        largest_region
+    } else if max_excluded.1 > largest_region.0
+        && max_excluded.1 < largest_region.1
+    {
+        (max_excluded.1, largest_region.1)
+    } else {
+        panic!("Unable to find suitable global alloc region")
+    }
+}
+
+pub fn early_init_multiboot(addr: HostPhysAddr) -> BootInfo {
+    fn multiboot_addr_translate<'a>(
+        paddr: u64,
+        size: usize,
+    ) -> Option<&'a [u8]> {
+        unsafe { Some(core::slice::from_raw_parts(paddr as *const u8, size)) }
+    }
+    let multiboot_info = unsafe {
+        multiboot::Multiboot::new(addr.as_u64(), multiboot_addr_translate)
+            .expect("Failed to create Multiboot structure")
+    };
+
+    let alloc_region = setup_global_alloc_region(&multiboot_info);
+
+    info!(
+        "Allocating from 0x{:x}-{:x}",
+        alloc_region.0, alloc_region.1
+    );
+
+    unsafe {
+        global_alloc::Allocator::allocate_from(alloc_region.0, alloc_region.1);
+    }
+
+    let modules = multiboot_info
+        .modules()
+        .expect("No multiboot modules found")
+        .map(|module| boot_info::BootModule {
+            address: HostPhysAddr::new(module.start),
+            size: (module.end - module.start) as usize,
+            identifier: module.string.map(alloc::string::String::from),
+        })
+        .collect::<Vec<_>>();
+
+    BootInfo {
+        modules: modules,
+        rsdp: None,
+    }
+}

--- a/mythril/src/multiboot2_header.S
+++ b/mythril/src/multiboot2_header.S
@@ -4,6 +4,7 @@ DEFAULT REL
 
 section .multiboot_header
 header_start:
+align 8
     dd 0xe85250d6                ; magic number (multiboot 2)
     dd 0                         ; architecture 0 (protected mode i386)
     dd header_end - header_start ; header length

--- a/mythril/src/multiboot_header.S
+++ b/mythril/src/multiboot_header.S
@@ -1,0 +1,26 @@
+DEFAULT REL
+
+[BITS 32]
+
+section .multiboot_header
+multiboot_header_start:
+align 4
+    dd 0x1BADB002                ; magic number (multiboot 1)
+    dd 0                         ; flags
+    ; checksum
+    dd -(0x1BADB002 + 0)
+    dd 0
+    dd 0
+    dd 0
+    dd 0
+    dd 0
+
+multiboot_header_end:
+
+global MULTIBOOT_HEADER_START
+MULTIBOOT_HEADER_START:
+    dd multiboot_header_start
+
+global MULTIBOOT_HEADER_END
+MULTIBOOT_HEADER_END:
+    dd multiboot_header_end


### PR DESCRIPTION
Unfortunately, we can't use this with direct grub boot as that only supports 32bit multiboot images. Still, there may be some value in using this for network booting, etc.