### PR TITLE
Add support for guest booting with APIC enabled

### DIFF
--- a/mythril/src/emulate/cpuid.rs
+++ b/mythril/src/emulate/cpuid.rs
@@ -20,6 +20,9 @@ pub fn emulate_cpuid(
 
         // Hide hypervisor feature
         res.ecx &= !(1 << 31);
+
+        // Hide TSC deadline timer
+        res.ecx &= !(1 << 24);
     }
 
     guest_cpu.rax = res.eax as u64 | (guest_cpu.rax & 0xffffffff00000000);

--- a/mythril/src/kmain.rs
+++ b/mythril/src/kmain.rs
@@ -117,10 +117,8 @@ fn build_vm(
     device_map
         .register_device(virtdev::rtc::CmosRtc::new(cfg.memory))
         .unwrap();
-
-    //TODO: this should actually be per-vcpu
     device_map
-        .register_device(virtdev::lapic::LocalApic::new())
+        .register_device(virtdev::ioapic::IoApic::new())
         .unwrap();
 
     let mut fw_cfg_builder = virtdev::qemu_fw_cfg::QemuFwCfgBuilder::new();

--- a/mythril/src/kmain.rs
+++ b/mythril/src/kmain.rs
@@ -63,7 +63,7 @@ fn build_vm(
     );
 
     let mut madt = acpi::madt::MADTBuilder::<[_; 8]>::new();
-    madt.set_ica(0xfee00000);
+    madt.set_ica(vm::GUEST_LOCAL_APIC_ADDR.as_u64() as u32);
     madt.add_ics(acpi::madt::Ics::LocalApic {
         apic_id: 0,
         apic_uid: 0,

--- a/mythril/src/memory.rs
+++ b/mythril/src/memory.rs
@@ -15,6 +15,12 @@ use x86::controlregs::Cr0;
 
 #[repr(align(4096))]
 pub struct Raw4kPage(pub [u8; BASE_PAGE_SIZE]);
+impl Raw4kPage {
+    pub fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr()
+    }
+}
+
 impl Default for Raw4kPage {
     fn default() -> Self {
         Raw4kPage([0u8; BASE_PAGE_SIZE])
@@ -148,7 +154,7 @@ impl Add<usize> for Guest4LevelPagingAddr {
 pub struct GuestPhysAddr(u64);
 
 impl GuestPhysAddr {
-    pub fn new(addr: u64) -> Self {
+    pub const fn new(addr: u64) -> Self {
         Self(addr)
     }
 

--- a/mythril/src/virtdev/ioapic.rs
+++ b/mythril/src/virtdev/ioapic.rs
@@ -1,0 +1,33 @@
+use crate::error::Result;
+use crate::memory::GuestPhysAddr;
+use crate::virtdev::{DeviceRegion, EmulatedDevice, Event};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use spin::RwLock;
+
+#[derive(Default)]
+pub struct IoApic;
+
+impl IoApic {
+    pub fn new() -> Arc<RwLock<Self>> {
+        Arc::new(RwLock::new(IoApic {}))
+    }
+}
+
+impl EmulatedDevice for IoApic {
+    fn services(&self) -> Vec<DeviceRegion> {
+        vec![
+            DeviceRegion::MemIo(
+                GuestPhysAddr::new(0xfec00000)..=GuestPhysAddr::new(0xfec010f0),
+            ),
+            //FIXME: this is actually the 1st HPET
+            DeviceRegion::MemIo(
+                GuestPhysAddr::new(0xfed00000)..=GuestPhysAddr::new(0xfed010f0),
+            ),
+        ]
+    }
+
+    fn on_event(&mut self, _event: Event) -> Result<()> {
+        Ok(())
+    }
+}

--- a/mythril/src/virtdev/lapic.rs
+++ b/mythril/src/virtdev/lapic.rs
@@ -1,37 +1,8 @@
-use crate::error::Result;
-use crate::memory::GuestPhysAddr;
-use crate::virtdev::{DeviceRegion, EmulatedDevice, Event};
-use alloc::sync::Arc;
-use alloc::vec::Vec;
-use spin::RwLock;
-
 #[derive(Default)]
 pub struct LocalApic;
 
 impl LocalApic {
-    pub fn new() -> Arc<RwLock<Self>> {
-        Arc::new(RwLock::new(LocalApic::default()))
-    }
-}
-
-impl EmulatedDevice for LocalApic {
-    fn services(&self) -> Vec<DeviceRegion> {
-        vec![
-            DeviceRegion::MemIo(
-                GuestPhysAddr::new(0xfee00000)..=GuestPhysAddr::new(0xfee010f0),
-            ),
-            //FIXME: this is actually the 1st HPET
-            DeviceRegion::MemIo(
-                GuestPhysAddr::new(0xfed00000)..=GuestPhysAddr::new(0xfed010f0),
-            ),
-            //FIXME: this is actually the io apic
-            DeviceRegion::MemIo(
-                GuestPhysAddr::new(0xfec00000)..=GuestPhysAddr::new(0xfec010f0),
-            ),
-        ]
-    }
-
-    fn on_event(&mut self, _event: Event) -> Result<()> {
-        Ok(())
+    pub fn new() -> Self {
+        LocalApic {}
     }
 }

--- a/mythril/src/virtdev/mod.rs
+++ b/mythril/src/virtdev/mod.rs
@@ -16,6 +16,7 @@ pub mod com;
 pub mod debug;
 pub mod dma;
 pub mod ignore;
+pub mod ioapic;
 pub mod keyboard;
 pub mod lapic;
 pub mod pci;

--- a/mythril/src/vm.rs
+++ b/mythril/src/vm.rs
@@ -25,7 +25,8 @@ use spin::RwLock;
 static BIOS_BLOB: &'static [u8] = include_bytes!("blob/bios.bin");
 
 //TODO(alschwalm): this should always be reported by the relevant MSR
-const GUEST_LOCAL_APIC_ADDR: GuestPhysAddr = GuestPhysAddr::new(0xfee00000);
+/// The location of the local apic in the guest address space
+pub const GUEST_LOCAL_APIC_ADDR: GuestPhysAddr = GuestPhysAddr::new(0xfee00000);
 
 static VIRTUAL_MACHINES: RoAfterInit<VirtualMachines> =
     RoAfterInit::uninitialized();

--- a/scripts/mythril.cfg
+++ b/scripts/mythril.cfg
@@ -6,14 +6,14 @@
 	    "cpus": [0],
 	    "kernel": "kernel",
 	    "initramfs": "initramfs",
-            "cmdline": "disableapic earlyprintk=serial,0x3f8,115200 console=ttyS0 debug nokaslr noapic root=/dev/ram0"
+            "cmdline": "earlyprintk=serial,0x3f8,115200 console=ttyS0 debug nokaslr root=/dev/ram0"
         },
         {
 	    "memory": 256,
 	    "cpus": [1],
 	    "kernel": "kernel",
 	    "initramfs": "initramfs",
-            "cmdline": "disableapic earlyprintk=serial,0x3f8,115200 console=ttyS0 debug nokaslr noapic root=/dev/ram0"
+            "cmdline": "earlyprintk=serial,0x3f8,115200 console=ttyS0 debug nokaslr root=/dev/ram0"
         }
     ]
 }


### PR DESCRIPTION
This starts to add support for guest apic interaction (which is necessary for multi core guest support). The initial steps here are as follows:

- Setup a guest APIC access page (this is shared by all cores, it is just the target page that is mapped by EPT for the local apic address range)
- For now, ignore all APIC access vm exits, just like we currently ignore PIC writes
- Move the local apic to being per-core
- Add an IoApic type that is a normal memory mapped device (though it currently doesn't do anything)