### PR TITLE
Resolve #78,  EmulatedDevice::services should access the VM config

### DIFF
--- a/mythril/src/kmain.rs
+++ b/mythril/src/kmain.rs
@@ -79,45 +79,46 @@ fn build_vm(
 
     acpi.add_sdt(madt).unwrap();
 
-    let device_map = config.virtual_devices_mut();
+    // let device_map = config.virtual_devices_mut();
+    let mut builder = config.device_map_builder();
 
-    device_map
+    builder
         .register_device(virtdev::acpi::AcpiRuntime::new(0x600).unwrap())
         .unwrap();
-    device_map
+    builder
         .register_device(virtdev::debug::DebugPort::new(0x402))
         .unwrap();
-    device_map
+    builder
         .register_device(virtdev::com::Uart8250::new(0x3F8))
         .unwrap();
-    device_map
+    builder
         .register_device(virtdev::vga::VgaController::new())
         .unwrap();
-    device_map
+    builder
         .register_device(virtdev::dma::Dma8237::new())
         .unwrap();
-    device_map
+    builder
         .register_device(virtdev::ignore::IgnoredDevice::new())
         .unwrap();
-    device_map
+    builder
         .register_device(virtdev::pci::PciRootComplex::new())
         .unwrap();
-    device_map
+    builder
         .register_device(virtdev::pic::Pic8259::new())
         .unwrap();
-    device_map
+    builder
         .register_device(virtdev::keyboard::Keyboard8042::new())
         .unwrap();
-    device_map
+    builder
         .register_device(virtdev::pit::Pit8254::new())
         .unwrap();
-    device_map
+    builder
         .register_device(virtdev::pos::ProgrammableOptionSelect::new())
         .unwrap();
-    device_map
+    builder
         .register_device(virtdev::rtc::CmosRtc::new(cfg.memory))
         .unwrap();
-    device_map
+    builder
         .register_device(virtdev::ioapic::IoApic::new())
         .unwrap();
 
@@ -151,7 +152,7 @@ fn build_vm(
     )
     .unwrap();
 
-    device_map.register_device(fw_cfg_builder.build()).unwrap();
+    builder.register_device(fw_cfg_builder.build()).unwrap();
 
     vm::VirtualMachine::new(cfg.cpus[0].raw, config, info)
         .expect("Failed to create vm")

--- a/mythril/src/virtdev/acpi.rs
+++ b/mythril/src/virtdev/acpi.rs
@@ -1,6 +1,6 @@
-use crate::error::Result;
 use crate::time;
 use crate::virtdev::{DeviceEvent, DeviceRegion, EmulatedDevice, Event, Port};
+use crate::{error::Result, vm::VirtualMachineConfig};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use spin::RwLock;
@@ -42,7 +42,7 @@ impl AcpiRuntime {
 }
 
 impl EmulatedDevice for AcpiRuntime {
-    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(
                 Self::FADT_SMI_COMMAND..=Self::FADT_SMI_COMMAND,

--- a/mythril/src/virtdev/acpi.rs
+++ b/mythril/src/virtdev/acpi.rs
@@ -42,7 +42,7 @@ impl AcpiRuntime {
 }
 
 impl EmulatedDevice for AcpiRuntime {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(
                 Self::FADT_SMI_COMMAND..=Self::FADT_SMI_COMMAND,

--- a/mythril/src/virtdev/com.rs
+++ b/mythril/src/virtdev/com.rs
@@ -1,9 +1,9 @@
-use crate::error::Result;
 use crate::physdev::com::*;
 use crate::vcpu;
 use crate::virtdev::{
     DeviceEvent, DeviceEventResponse, DeviceRegion, EmulatedDevice, Event, Port,
 };
+use crate::{error::Result, vm::VirtualMachineConfig};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::convert::TryInto;
@@ -54,7 +54,7 @@ impl Uart8250 {
 }
 
 impl EmulatedDevice for Uart8250 {
-    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![DeviceRegion::PortIo(self.base_port..=self.base_port + 7)]
     }
 

--- a/mythril/src/virtdev/com.rs
+++ b/mythril/src/virtdev/com.rs
@@ -54,7 +54,7 @@ impl Uart8250 {
 }
 
 impl EmulatedDevice for Uart8250 {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![DeviceRegion::PortIo(self.base_port..=self.base_port + 7)]
     }
 

--- a/mythril/src/virtdev/debug.rs
+++ b/mythril/src/virtdev/debug.rs
@@ -1,7 +1,7 @@
-use crate::error::Result;
 use crate::virtdev::{
     DeviceEvent, DeviceEventResponse, DeviceRegion, EmulatedDevice, Event, Port,
 };
+use crate::{error::Result, vm::VirtualMachineConfig};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::convert::TryInto;
@@ -18,7 +18,7 @@ impl DebugPort {
 }
 
 impl EmulatedDevice for DebugPort {
-    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![DeviceRegion::PortIo(self.port..=self.port)]
     }
 

--- a/mythril/src/virtdev/debug.rs
+++ b/mythril/src/virtdev/debug.rs
@@ -18,7 +18,7 @@ impl DebugPort {
 }
 
 impl EmulatedDevice for DebugPort {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![DeviceRegion::PortIo(self.port..=self.port)]
     }
 

--- a/mythril/src/virtdev/dma.rs
+++ b/mythril/src/virtdev/dma.rs
@@ -1,5 +1,5 @@
-use crate::error::Result;
 use crate::virtdev::{DeviceRegion, EmulatedDevice, Event, Port};
+use crate::{error::Result, vm::VirtualMachineConfig};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use spin::RwLock;
@@ -31,7 +31,7 @@ impl Dma8237 {
 }
 
 impl EmulatedDevice for Dma8237 {
-    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(
                 Self::DMA1_CHAN2_ADDR..=Self::DMA1_MASTER_CLEAR,

--- a/mythril/src/virtdev/dma.rs
+++ b/mythril/src/virtdev/dma.rs
@@ -31,7 +31,7 @@ impl Dma8237 {
 }
 
 impl EmulatedDevice for Dma8237 {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(
                 Self::DMA1_CHAN2_ADDR..=Self::DMA1_MASTER_CLEAR,

--- a/mythril/src/virtdev/ignore.rs
+++ b/mythril/src/virtdev/ignore.rs
@@ -1,5 +1,5 @@
-use crate::error::Result;
 use crate::virtdev::{DeviceRegion, EmulatedDevice, Event};
+use crate::{error::Result, vm::VirtualMachineConfig};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use spin::RwLock;
@@ -17,7 +17,7 @@ impl IgnoredDevice {
 }
 
 impl EmulatedDevice for IgnoredDevice {
-    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             // Ignore #IGNNE stuff
             DeviceRegion::PortIo(241..=241),

--- a/mythril/src/virtdev/ignore.rs
+++ b/mythril/src/virtdev/ignore.rs
@@ -17,7 +17,7 @@ impl IgnoredDevice {
 }
 
 impl EmulatedDevice for IgnoredDevice {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             // Ignore #IGNNE stuff
             DeviceRegion::PortIo(241..=241),

--- a/mythril/src/virtdev/ioapic.rs
+++ b/mythril/src/virtdev/ioapic.rs
@@ -1,6 +1,6 @@
-use crate::error::Result;
 use crate::memory::GuestPhysAddr;
 use crate::virtdev::{DeviceRegion, EmulatedDevice, Event};
+use crate::{error::Result, vm::VirtualMachineConfig};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use spin::RwLock;
@@ -15,7 +15,7 @@ impl IoApic {
 }
 
 impl EmulatedDevice for IoApic {
-    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::MemIo(
                 GuestPhysAddr::new(0xfec00000)..=GuestPhysAddr::new(0xfec010f0),

--- a/mythril/src/virtdev/ioapic.rs
+++ b/mythril/src/virtdev/ioapic.rs
@@ -15,7 +15,7 @@ impl IoApic {
 }
 
 impl EmulatedDevice for IoApic {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::MemIo(
                 GuestPhysAddr::new(0xfec00000)..=GuestPhysAddr::new(0xfec010f0),

--- a/mythril/src/virtdev/keyboard.rs
+++ b/mythril/src/virtdev/keyboard.rs
@@ -1,5 +1,5 @@
-use crate::error::Result;
 use crate::virtdev::{DeviceEvent, DeviceRegion, EmulatedDevice, Event, Port};
+use crate::{error::Result, vm::VirtualMachineConfig};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use spin::RwLock;
@@ -17,7 +17,7 @@ impl Keyboard8042 {
 }
 
 impl EmulatedDevice for Keyboard8042 {
-    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(Self::PS2_DATA..=Self::PS2_DATA),
             DeviceRegion::PortIo(Self::PS2_STATUS..=Self::PS2_STATUS),

--- a/mythril/src/virtdev/keyboard.rs
+++ b/mythril/src/virtdev/keyboard.rs
@@ -17,7 +17,7 @@ impl Keyboard8042 {
 }
 
 impl EmulatedDevice for Keyboard8042 {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(Self::PS2_DATA..=Self::PS2_DATA),
             DeviceRegion::PortIo(Self::PS2_STATUS..=Self::PS2_STATUS),

--- a/mythril/src/virtdev/mod.rs
+++ b/mythril/src/virtdev/mod.rs
@@ -499,7 +499,7 @@ impl<'a> fmt::Display for MemReadRequest<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::virtdev::com::*;
+    use crate::{virtdev::com::*, vm::PhysicalDeviceConfig};
     use core::convert::TryInto;
 
     // This is just a dummy device so we can have arbitrary port ranges
@@ -528,17 +528,25 @@ mod test {
         }
     }
 
+    #[test]
+    fn test_device_map() {
+        let mut config = VirtualMachineConfig::new(
+            vec![0.into()],
+            1024,
+            PhysicalDeviceConfig::default(),
+        );
+
+        let mut builder = config.device_map_builder();
+        let com = Uart8250::new(0);
+        builder.register_device(com).unwrap();
+
+        let map = config.virtual_devices();
+        let _dev = map.find_device(0u16).unwrap();
+
+        assert_eq!(map.find_device(10u16).is_none(), true);
+    }
+
     /*
-        #[test]
-        fn test_device_map() {
-            let mut map = DeviceMap::default();
-            let com = Uart8250::new(0);
-            map.register_device(com).unwrap();
-            let _dev = map.find_device(0u16).unwrap();
-
-            assert_eq!(map.find_device(10u16).is_none(), true);
-        }
-
         #[test]
         fn test_write_request_try_from() {
             let val: Result<PortWriteRequest> =

--- a/mythril/src/virtdev/mod.rs
+++ b/mythril/src/virtdev/mod.rs
@@ -546,94 +546,128 @@ mod test {
         assert_eq!(map.find_device(10u16).is_none(), true);
     }
 
-    /*
-        #[test]
-        fn test_write_request_try_from() {
-            let val: Result<PortWriteRequest> =
-                [0x12, 0x34, 0x56, 0x78][..].try_into();
-            assert_eq!(val.is_ok(), true);
+    
+    #[test]
+    fn test_write_request_try_from() {
+        let val: Result<PortWriteRequest> =
+            [0x12, 0x34, 0x56, 0x78][..].try_into();
+        assert_eq!(val.is_ok(), true);
 
-            let val: Result<PortWriteRequest> = [0x12, 0x34, 0x56][..].try_into();
-            assert_eq!(val.is_err(), true);
+        let val: Result<PortWriteRequest> = [0x12, 0x34, 0x56][..].try_into();
+        assert_eq!(val.is_err(), true);
 
-            let val: PortWriteRequest =
-                [0x12, 0x34, 0x56, 0x78][..].try_into().unwrap();
-            assert_eq!(val.as_u32(), 0x12345678);
+        let val: PortWriteRequest =
+            [0x12, 0x34, 0x56, 0x78][..].try_into().unwrap();
+        assert_eq!(val.as_u32(), 0x12345678);
 
-            let val: PortWriteRequest = [0x12, 0x34][..].try_into().unwrap();
-            assert_eq!(val.as_u32(), 0x1234);
-        }
+        let val: PortWriteRequest = [0x12, 0x34][..].try_into().unwrap();
+        assert_eq!(val.as_u32(), 0x1234);
+    }
+    
+    #[test]
+    fn test_portio_value_read() {
+        let mut arr = [0x00, 0x00];
+        let mut val = PortReadRequest::TwoBytes(&mut arr);
+        val.copy_from_u32(0x1234u32);
+        assert_eq!([0x12, 0x34], val.as_slice());
+        assert_eq!(0x1234, u16::from_be_bytes(arr));
+    }
+    
+    #[test]
+    fn test_conflicting_portio_device() {
+        let mut config = VirtualMachineConfig::new(
+            vec![0.into()],
+            1024,
+            PhysicalDeviceConfig::default(),
+        );
 
-        #[test]
-        fn test_portio_value_read() {
-            let mut arr = [0x00, 0x00];
-            let mut val = PortReadRequest::TwoBytes(&mut arr);
-            val.copy_from_u32(0x1234u32);
-            assert_eq!([0x12, 0x34], val.as_slice());
-            assert_eq!(0x1234, u16::from_be_bytes(arr));
-        }
+        let mut builder = config.device_map_builder();
+        let com = Uart8250::new(0);
+        builder.register_device(com).unwrap();
+        let com = Uart8250::new(0);
 
-        #[test]
-        fn test_conflicting_portio_device() {
-            let mut map = DeviceMap::default();
-            let com = Uart8250::new(0);
-            map.register_device(com).unwrap();
-            let com = Uart8250::new(0);
+        assert!(builder.register_device(com).is_err());
+    }
+    
+    #[test]
+    fn test_fully_overlapping_portio_device() {
+        // region 2 fully inside region 1
+        let services = vec![0..=10, 2..=8];
+        let dummy = DummyDevice::new(services);
+        let mut config = VirtualMachineConfig::new(
+            vec![0.into()],
+            1024,
+            PhysicalDeviceConfig::default(),
+        );
 
-            assert!(map.register_device(com).is_err());
-        }
+        let mut builder = config.device_map_builder();
 
-        #[test]
-        fn test_fully_overlapping_portio_device() {
-            // region 2 fully inside region 1
-            let services = vec![0..=10, 2..=8];
-            let dummy = DummyDevice::new(services);
-            let mut map = DeviceMap::default();
+        assert!(builder.register_device(dummy).is_err());
+    }
+    
+    #[test]
+    fn test_fully_encompassing_portio_device() {
+        // region 1 fully inside region 2
+        let services = vec![2..=8, 0..=10];
+        let dummy = DummyDevice::new(services);
+        let mut config = VirtualMachineConfig::new(
+            vec![0.into()],
+            1024,
+            PhysicalDeviceConfig::default(),
+        );
 
-            assert!(map.register_device(dummy).is_err());
-        }
+        let mut builder = config.device_map_builder();
 
-        #[test]
-        fn test_fully_encompassing_portio_device() {
-            // region 1 fully inside region 2
-            let services = vec![2..=8, 0..=10];
-            let dummy = DummyDevice::new(services);
-            let mut map = DeviceMap::default();
+        assert!(builder.register_device(dummy).is_err());
+    }
+    
+    #[test]
+    fn test_partially_overlapping_tail_portio_device() {
+        // region 1 and region 2 partially overlap at the tail of region 1 and
+        // the start of region 2
+        let services = vec![0..=4, 3..=8];
+        let dummy = DummyDevice::new(services);
+        let mut config = VirtualMachineConfig::new(
+            vec![0.into()],
+            1024,
+            PhysicalDeviceConfig::default(),
+        );
 
-            assert!(map.register_device(dummy).is_err());
-        }
+        let mut builder = config.device_map_builder();
 
-        #[test]
-        fn test_partially_overlapping_tail_portio_device() {
-            // region 1 and region 2 partially overlap at the tail of region 1 and
-            // the start of region 2
-            let services = vec![0..=4, 3..=8];
-            let dummy = DummyDevice::new(services);
-            let mut map = DeviceMap::default();
+        assert!(builder.register_device(dummy).is_err());
+    }
+    
+    #[test]
+    fn test_partially_overlapping_head_portio_device() {
+        // region 1 and region 2 partially overlap at the start of region 1 and
+        // the tail of region 2
+        let services = vec![3..=8, 0..=4];
+        let dummy = DummyDevice::new(services);
+        let mut config = VirtualMachineConfig::new(
+            vec![0.into()],
+            1024,
+            PhysicalDeviceConfig::default(),
+        );
 
-            assert!(map.register_device(dummy).is_err());
-        }
+        let mut builder = config.device_map_builder();
 
-        #[test]
-        fn test_partially_overlapping_head_portio_device() {
-            // region 1 and region 2 partially overlap at the start of region 1 and
-            // the tail of region 2
-            let services = vec![3..=8, 0..=4];
-            let dummy = DummyDevice::new(services);
-            let mut map = DeviceMap::default();
+        assert!(builder.register_device(dummy).is_err());
+    }
+    
+    #[test]
+    fn test_non_overlapping_portio_device() {
+        // region 1 and region 2 don't overlap
+        let services = vec![0..=3, 4..=8];
+        let dummy = DummyDevice::new(services);
+        let mut config = VirtualMachineConfig::new(
+            vec![0.into()],
+            1024,
+            PhysicalDeviceConfig::default(),
+        );
 
-            assert!(map.register_device(dummy).is_err());
-        }
+        let mut builder = config.device_map_builder();
 
-        #[test]
-        fn test_non_overlapping_portio_device() {
-            // region 1 and region 2 don't overlap
-            let services = vec![0..=3, 4..=8];
-            let dummy = DummyDevice::new(services);
-            let mut map = DeviceMap::default();
-
-            assert!(map.register_device(dummy).is_ok());
-        }
-
-    */
+        assert!(builder.register_device(dummy).is_ok());
+    }
 }

--- a/mythril/src/virtdev/mod.rs
+++ b/mythril/src/virtdev/mod.rs
@@ -516,6 +516,17 @@ mod test {
         }
     }
 
+    impl VirtualMachineConfig {
+        // Default config used for testing
+        pub fn default() -> VirtualMachineConfig {
+            VirtualMachineConfig::new(
+                vec![0.into()],
+                1024,
+                PhysicalDeviceConfig::default(),
+            )
+        }    
+    }
+
     impl EmulatedDevice for DummyDevice {
         fn services(
             &self,
@@ -530,11 +541,7 @@ mod test {
 
     #[test]
     fn test_device_map() {
-        let mut config = VirtualMachineConfig::new(
-            vec![0.into()],
-            1024,
-            PhysicalDeviceConfig::default(),
-        );
+        let mut config = VirtualMachineConfig::default();
 
         let mut builder = config.device_map_builder();
         let com = Uart8250::new(0);
@@ -575,11 +582,7 @@ mod test {
     
     #[test]
     fn test_conflicting_portio_device() {
-        let mut config = VirtualMachineConfig::new(
-            vec![0.into()],
-            1024,
-            PhysicalDeviceConfig::default(),
-        );
+        let mut config = VirtualMachineConfig::default();
 
         let mut builder = config.device_map_builder();
         let com = Uart8250::new(0);
@@ -594,11 +597,7 @@ mod test {
         // region 2 fully inside region 1
         let services = vec![0..=10, 2..=8];
         let dummy = DummyDevice::new(services);
-        let mut config = VirtualMachineConfig::new(
-            vec![0.into()],
-            1024,
-            PhysicalDeviceConfig::default(),
-        );
+        let mut config = VirtualMachineConfig::default();
 
         let mut builder = config.device_map_builder();
 
@@ -610,11 +609,7 @@ mod test {
         // region 1 fully inside region 2
         let services = vec![2..=8, 0..=10];
         let dummy = DummyDevice::new(services);
-        let mut config = VirtualMachineConfig::new(
-            vec![0.into()],
-            1024,
-            PhysicalDeviceConfig::default(),
-        );
+        let mut config = VirtualMachineConfig::default();
 
         let mut builder = config.device_map_builder();
 
@@ -627,11 +622,7 @@ mod test {
         // the start of region 2
         let services = vec![0..=4, 3..=8];
         let dummy = DummyDevice::new(services);
-        let mut config = VirtualMachineConfig::new(
-            vec![0.into()],
-            1024,
-            PhysicalDeviceConfig::default(),
-        );
+        let mut config = VirtualMachineConfig::default();
 
         let mut builder = config.device_map_builder();
 
@@ -644,11 +635,7 @@ mod test {
         // the tail of region 2
         let services = vec![3..=8, 0..=4];
         let dummy = DummyDevice::new(services);
-        let mut config = VirtualMachineConfig::new(
-            vec![0.into()],
-            1024,
-            PhysicalDeviceConfig::default(),
-        );
+        let mut config = VirtualMachineConfig::default();
 
         let mut builder = config.device_map_builder();
 
@@ -660,11 +647,7 @@ mod test {
         // region 1 and region 2 don't overlap
         let services = vec![0..=3, 4..=8];
         let dummy = DummyDevice::new(services);
-        let mut config = VirtualMachineConfig::new(
-            vec![0.into()],
-            1024,
-            PhysicalDeviceConfig::default(),
-        );
+        let mut config = VirtualMachineConfig::default();
 
         let mut builder = config.device_map_builder();
 

--- a/mythril/src/virtdev/pci.rs
+++ b/mythril/src/virtdev/pci.rs
@@ -189,7 +189,7 @@ impl PciRootComplex {
 }
 
 impl EmulatedDevice for PciRootComplex {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(
                 Self::PCI_CONFIG_ADDRESS..=Self::PCI_CONFIG_ADDRESS,

--- a/mythril/src/virtdev/pci.rs
+++ b/mythril/src/virtdev/pci.rs
@@ -1,5 +1,8 @@
-use crate::error::{Error, Result};
 use crate::virtdev::{DeviceEvent, DeviceRegion, EmulatedDevice, Event, Port};
+use crate::{
+    error::{Error, Result},
+    vm::VirtualMachineConfig,
+};
 use alloc::collections::btree_map::BTreeMap;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -189,7 +192,7 @@ impl PciRootComplex {
 }
 
 impl EmulatedDevice for PciRootComplex {
-    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(
                 Self::PCI_CONFIG_ADDRESS..=Self::PCI_CONFIG_ADDRESS,

--- a/mythril/src/virtdev/pic.rs
+++ b/mythril/src/virtdev/pic.rs
@@ -1,5 +1,5 @@
-use crate::error::Result;
 use crate::virtdev::{DeviceEvent, DeviceRegion, EmulatedDevice, Event, Port};
+use crate::{error::Result, vm::VirtualMachineConfig};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::convert::TryInto;
@@ -30,7 +30,7 @@ impl Pic8259 {
 }
 
 impl EmulatedDevice for Pic8259 {
-    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(
                 Self::PIC_MASTER_COMMAND..=Self::PIC_MASTER_DATA,

--- a/mythril/src/virtdev/pic.rs
+++ b/mythril/src/virtdev/pic.rs
@@ -30,7 +30,7 @@ impl Pic8259 {
 }
 
 impl EmulatedDevice for Pic8259 {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(
                 Self::PIC_MASTER_COMMAND..=Self::PIC_MASTER_DATA,

--- a/mythril/src/virtdev/pit.rs
+++ b/mythril/src/virtdev/pit.rs
@@ -1,9 +1,12 @@
-use crate::error::{Error, Result};
 use crate::physdev::pit::*;
 use crate::time;
 use crate::virtdev::{
     DeviceEvent, DeviceRegion, EmulatedDevice, Event, Port, PortReadRequest,
     PortWriteRequest,
+};
+use crate::{
+    error::{Error, Result},
+    vm::VirtualMachineConfig,
 };
 
 use alloc::sync::Arc;
@@ -259,7 +262,7 @@ impl Pit8254 {
 }
 
 impl EmulatedDevice for Pit8254 {
-    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(PIT_COUNTER_0..=PIT_MODE_CONTROL),
             DeviceRegion::PortIo(PIT_PS2_CTRL_B..=PIT_PS2_CTRL_B),

--- a/mythril/src/virtdev/pit.rs
+++ b/mythril/src/virtdev/pit.rs
@@ -259,7 +259,7 @@ impl Pit8254 {
 }
 
 impl EmulatedDevice for Pit8254 {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(PIT_COUNTER_0..=PIT_MODE_CONTROL),
             DeviceRegion::PortIo(PIT_PS2_CTRL_B..=PIT_PS2_CTRL_B),

--- a/mythril/src/virtdev/pos.rs
+++ b/mythril/src/virtdev/pos.rs
@@ -1,5 +1,5 @@
-use crate::error::Result;
 use crate::virtdev::{DeviceEvent, DeviceRegion, EmulatedDevice, Event, Port};
+use crate::{error::Result, vm::VirtualMachineConfig};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use spin::RwLock;
@@ -24,7 +24,7 @@ impl ProgrammableOptionSelect {
 // Currently we don't actually implement any of this, but I don't think we
 // need to either (kvm doesn't seem to)
 impl EmulatedDevice for ProgrammableOptionSelect {
-    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![DeviceRegion::PortIo(
             Self::POS_ARBITRATION_CLOCK..=Self::POS_ADAPTER_ENABLE_SETUP,
         )]

--- a/mythril/src/virtdev/pos.rs
+++ b/mythril/src/virtdev/pos.rs
@@ -24,7 +24,7 @@ impl ProgrammableOptionSelect {
 // Currently we don't actually implement any of this, but I don't think we
 // need to either (kvm doesn't seem to)
 impl EmulatedDevice for ProgrammableOptionSelect {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![DeviceRegion::PortIo(
             Self::POS_ARBITRATION_CLOCK..=Self::POS_ADAPTER_ENABLE_SETUP,
         )]

--- a/mythril/src/virtdev/qemu_fw_cfg.rs
+++ b/mythril/src/virtdev/qemu_fw_cfg.rs
@@ -1,4 +1,3 @@
-use crate::error::{Error, Result};
 use crate::memory::{
     GuestAccess, GuestAddressSpaceViewMut, GuestPhysAddr, GuestVirtAddr,
     PrivilegeLevel,
@@ -6,6 +5,10 @@ use crate::memory::{
 use crate::virtdev::{
     DeviceEvent, DeviceRegion, EmulatedDevice, Event, Port, PortReadRequest,
     PortWriteRequest,
+};
+use crate::{
+    error::{Error, Result},
+    vm::VirtualMachineConfig,
 };
 use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
@@ -388,7 +391,7 @@ impl QemuFwCfg {
 }
 
 impl EmulatedDevice for QemuFwCfg {
-    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(
                 Self::FW_CFG_PORT_SEL..=Self::FW_CFG_PORT_DATA,

--- a/mythril/src/virtdev/qemu_fw_cfg.rs
+++ b/mythril/src/virtdev/qemu_fw_cfg.rs
@@ -388,7 +388,7 @@ impl QemuFwCfg {
 }
 
 impl EmulatedDevice for QemuFwCfg {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             DeviceRegion::PortIo(
                 Self::FW_CFG_PORT_SEL..=Self::FW_CFG_PORT_DATA,

--- a/mythril/src/virtdev/rtc.rs
+++ b/mythril/src/virtdev/rtc.rs
@@ -167,7 +167,7 @@ impl CmosRtc {
 
 //TODO: support the NMI masking stuff
 impl EmulatedDevice for CmosRtc {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![DeviceRegion::PortIo(Self::RTC_ADDRESS..=Self::RTC_DATA)]
     }
 

--- a/mythril/src/virtdev/rtc.rs
+++ b/mythril/src/virtdev/rtc.rs
@@ -1,8 +1,8 @@
-use crate::error::Result;
 use crate::virtdev::{
     DeviceEvent, DeviceRegion, EmulatedDevice, Event, Port, PortReadRequest,
     PortWriteRequest,
 };
+use crate::{error::Result, vm::VirtualMachineConfig};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};
@@ -167,7 +167,7 @@ impl CmosRtc {
 
 //TODO: support the NMI masking stuff
 impl EmulatedDevice for CmosRtc {
-    fn services(&self, _vm_config: VirtualMachineConfig) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![DeviceRegion::PortIo(Self::RTC_ADDRESS..=Self::RTC_DATA)]
     }
 

--- a/mythril/src/virtdev/vga.rs
+++ b/mythril/src/virtdev/vga.rs
@@ -1,7 +1,10 @@
-use crate::error::{Error, Result};
 use crate::virtdev::{
     DeviceEvent, DeviceRegion, EmulatedDevice, Event, Port, PortReadRequest,
     PortWriteRequest,
+};
+use crate::{
+    error::{Error, Result},
+    vm::VirtualMachineConfig,
 };
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -128,7 +131,7 @@ impl VgaController {
 }
 
 impl EmulatedDevice for VgaController {
-    fn services(&self) -> Vec<DeviceRegion> {
+    fn services(&self, _vm_config: &VirtualMachineConfig) -> Vec<DeviceRegion> {
         vec![
             // vga stuff
             DeviceRegion::PortIo(Self::VGA_INDEX..=Self::VGA_DATA),

--- a/mythril/src/vm.rs
+++ b/mythril/src/vm.rs
@@ -274,6 +274,12 @@ impl VirtualMachineConfig {
         &mut self.virtual_devices
     }
 
+    pub fn device_map_builder(&mut self) -> DeviceMapBuilder<'_> {
+        DeviceMapBuilder {
+            vm_config: self
+        }
+    }
+
     pub fn physical_devices(&self) -> &PhysicalDeviceConfig {
         &self.physical_devices
     }

--- a/mythril/src/vm.rs
+++ b/mythril/src/vm.rs
@@ -1,4 +1,3 @@
-use crate::apic;
 use crate::boot_info::BootInfo;
 use crate::error::{Error, Result};
 use crate::interrupt;
@@ -13,6 +12,7 @@ use crate::time;
 use crate::virtdev::{
     DeviceEvent, DeviceInteraction, DeviceMap, Event, ResponseEventArray,
 };
+use crate::{apic, virtdev::DeviceMapBuilder};
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use alloc::string::String;
@@ -275,9 +275,7 @@ impl VirtualMachineConfig {
     }
 
     pub fn device_map_builder(&mut self) -> DeviceMapBuilder<'_> {
-        DeviceMapBuilder {
-            vm_config: self
-        }
+        DeviceMapBuilder { vm_config: self }
     }
 
     pub fn physical_devices(&self) -> &PhysicalDeviceConfig {


### PR DESCRIPTION
Resolve issue #78 
* Changes `EmulatedDevice::services` method to access the virtual machine config
* Adds a new struct called `DeviceMapBuilder` to be able to manipulate `DeviceMap` through `VirtualMachineConfig`